### PR TITLE
Publish Android artifacts to Maven Central

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = '1.8'
         useIR = true
     }
     buildFeatures {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
         compose_version = '1.0.0-alpha06'
@@ -11,13 +10,12 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0-alpha15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 
 allprojects {
+    version = '0.1.0-dev02-SNAPSHOT'
+
     repositories {
         google()
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,21 @@ allprojects {
     }
 }
 
+subprojects { project ->
+    afterEvaluate {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                jvmTarget = '1.8'
+                // avoid kotlin_module clash for projects with the same name, e.g. 'ui' & 'routes:ui"
+                // https://discuss.kotlinlang.org/t/dealing-with-kotlin-module-conflict-when-building-apk-for-project-with-non-unique-project-names/11247
+                if (project.hasProperty('PUBLISH_ARTIFACT_ID')) {
+                    freeCompilerArgs += ['-module-name', "com.trafi.maas.$PUBLISH_ARTIFACT_ID"]
+                }
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -20,9 +20,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
     sourceSets {
         main.java.srcDirs += generatedModelPath
     }

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -89,3 +89,9 @@ task swagen {
     dependsOn(fetchSwaggerSchema, generateModels)
     finalizedBy(ktlintFormat)
 }
+
+ext {
+    PUBLISH_ARTIFACT_ID = 'core-android'
+}
+
+apply from: "${rootProject.projectDir}/scripts/maven.gradle"

--- a/android/locations/build.gradle
+++ b/android/locations/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    implementation project(":core")
+    api project(":core")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/android/locations/build.gradle
+++ b/android/locations/build.gradle
@@ -14,9 +14,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {

--- a/android/locations/build.gradle
+++ b/android/locations/build.gradle
@@ -28,3 +28,9 @@ dependencies {
     implementation 'com.squareup.moshi:moshi:1.10.0'
     implementation 'com.squareup.moshi:moshi-kotlin:1.10.0'
 }
+
+ext {
+    PUBLISH_ARTIFACT_ID = 'locations-android'
+}
+
+apply from: "${rootProject.projectDir}/scripts/maven.gradle"

--- a/android/routes/build.gradle
+++ b/android/routes/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    implementation project(":core")
+    api project(":core")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/android/routes/build.gradle
+++ b/android/routes/build.gradle
@@ -14,9 +14,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {

--- a/android/routes/build.gradle
+++ b/android/routes/build.gradle
@@ -28,3 +28,9 @@ dependencies {
     implementation 'com.squareup.moshi:moshi:1.10.0'
     implementation 'com.squareup.moshi:moshi-kotlin:1.10.0'
 }
+
+ext {
+    PUBLISH_ARTIFACT_ID = 'routes-android'
+}
+
+apply from: "${rootProject.projectDir}/scripts/maven.gradle"

--- a/android/routes/ui/build.gradle
+++ b/android/routes/ui/build.gradle
@@ -35,3 +35,9 @@ dependencies {
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.ui:ui-tooling:$compose_version"
 }
+
+ext {
+    PUBLISH_ARTIFACT_ID = 'routes-ui-android'
+}
+
+apply from: "${rootProject.projectDir}/scripts/maven.gradle"

--- a/android/routes/ui/build.gradle
+++ b/android/routes/ui/build.gradle
@@ -9,10 +9,8 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-        kotlinOptions.freeCompilerArgs += ['-module-name', 'com.trafi.routes-ui']
     }
     kotlinOptions {
-        jvmTarget = '1.8'
         useIR = true
     }
     buildFeatures {

--- a/android/routes/ui/build.gradle
+++ b/android/routes/ui/build.gradle
@@ -23,8 +23,8 @@ android {
 }
 
 dependencies {
-    implementation project(":core")
-    implementation project(":ui")
+    api project(":core")
+    api project(":ui")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/android/scripts/maven.gradle
+++ b/android/scripts/maven.gradle
@@ -1,13 +1,3 @@
-task androidSourcesJar(type: Jar) {
-    //noinspection GrDeprecatedAPIUsage
-    classifier = 'sources'
-    from android.sourceSets.main.java.source
-}
-
-artifacts {
-    archives androidSourcesJar
-}
-
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
@@ -17,76 +7,53 @@ ext["signing.secretKeyRingFile"] = resolveProperty("signing.secretKeyRingFile", 
 ext["sonatypeUsername"] = resolveProperty("sonatypeUsername", "SONATYPE_USERNAME")
 ext["sonatypePassword"] = resolveProperty("sonatypePassword", "SONATYPE_PASSWORD")
 
-publishing {
-    publications {
-        release(MavenPublication) {
-            groupId 'com.trafi.maas'
-            artifactId PUBLISH_ARTIFACT_ID
-            version '0.1.0-dev01'
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId 'com.trafi.maas'
+                artifactId PUBLISH_ARTIFACT_ID
 
-            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
-            artifact androidSourcesJar
+                from components.release
+                artifact androidSourcesJar
 
-            pom {
-                name = 'MaaS Components'
-                description = 'Mobility-as-a-service SDK & UI components'
-                url = 'https://github.com/trafi/maas-components'
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'trafi'
-                        name = 'Trafi Ltd.'
-                        email = 'development@trafi.com'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:https://github.com/trafi/maas-components.git'
-                    developerConnection = 'scm:git:ssh://github.com/trafi/maas-components.git'
+                pom {
+                    name = 'MaaS Components'
+                    description = 'Mobility-as-a-service SDK & UI components'
                     url = 'https://github.com/trafi/maas-components'
-                }
-
-                // A slightly hacky fix so that your POM will include any transitive dependencies
-                // that your library builds upon
-                withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    project.configurations.implementation.allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        if (it.group == 'maas-components-android') {
-                            dependencyNode.appendNode('groupId', groupId)
-                            dependencyNode.appendNode('artifactId',
-                                    it.name == 'core'
-                                            ? 'core-android'
-                                            : it.name == 'ui'
-                                            ? 'ui-android'
-                                            : it.name)
-                            dependencyNode.appendNode('version', version)
-                        } else {
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
+                    }
+                    developers {
+                        developer {
+                            id = 'trafi'
+                            name = 'Trafi Ltd.'
+                            email = 'development@trafi.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:https://github.com/trafi/maas-components.git'
+                        developerConnection = 'scm:git:ssh://github.com/trafi/maas-components.git'
+                        url = 'https://github.com/trafi/maas-components'
                     }
                 }
             }
         }
-    }
-    repositories {
-        maven {
-            name = "sonatype"
+        repositories {
+            maven {
+                name = "sonatype"
 
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-            credentials {
-                username sonatypeUsername
-                password sonatypePassword
+                credentials {
+                    username sonatypeUsername
+                    password sonatypePassword
+                }
             }
         }
     }
@@ -94,4 +61,14 @@ publishing {
 
 signing {
     sign publishing.publications
+}
+
+task androidSourcesJar(type: Jar) {
+    //noinspection GrDeprecatedAPIUsage
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+}
+
+artifacts {
+    archives androidSourcesJar
 }

--- a/android/scripts/maven.gradle
+++ b/android/scripts/maven.gradle
@@ -1,0 +1,91 @@
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.source
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+ext["signing.keyId"] = resolveProperty("signing.keyId", "MAVEN_SIGNING_KEY_ID")
+ext["signing.password"] = resolveProperty("signing.password", "MAVEN_SIGNING_KEY_PASSOWRD")
+ext["signing.secretKeyRingFile"] = resolveProperty("signing.secretKeyRingFile", "MAVEN_SIGNING_KEY_RING_FILE")
+ext["sonatypeUsername"] = resolveProperty("sonatypeUsername", "SONATYPE_USERNAME")
+ext["sonatypePassword"] = resolveProperty("sonatypePassword", "SONATYPE_PASSWORD")
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId 'com.trafi.maas'
+            artifactId PUBLISH_ARTIFACT_ID
+            version '0.1.0-dev01'
+
+            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact androidSourcesJar
+
+            pom {
+                name = 'MaaS Components'
+                description = 'Mobility-as-a-service SDK & UI components'
+                url = 'https://github.com/trafi/maas-components'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'trafi'
+                        name = 'Trafi Ltd.'
+                        email = 'development@trafi.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/trafi/maas-components.git'
+                    developerConnection = 'scm:git:ssh://github.com/trafi/maas-components.git'
+                    url = 'https://github.com/trafi/maas-components'
+                }
+
+                // A slightly hacky fix so that your POM will include any transitive dependencies
+                // that your library builds upon
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        if (it.group == 'maas-components-android') {
+                            dependencyNode.appendNode('groupId', groupId)
+                            dependencyNode.appendNode('artifactId', it.name == 'core' ? 'core-android' : it.name)
+                            dependencyNode.appendNode('version', version)
+                        } else {
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "sonatype"
+
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+            credentials {
+                username sonatypeUsername
+                password sonatypePassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/android/scripts/maven.gradle
+++ b/android/scripts/maven.gradle
@@ -58,7 +58,12 @@ publishing {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
                         if (it.group == 'maas-components-android') {
                             dependencyNode.appendNode('groupId', groupId)
-                            dependencyNode.appendNode('artifactId', it.name == 'core' ? 'core-android' : it.name)
+                            dependencyNode.appendNode('artifactId',
+                                    it.name == 'core'
+                                            ? 'core-android'
+                                            : it.name == 'ui'
+                                            ? 'ui-android'
+                                            : it.name)
                             dependencyNode.appendNode('version', version)
                         } else {
                             dependencyNode.appendNode('groupId', it.group)

--- a/android/scripts/maven.gradle
+++ b/android/scripts/maven.gradle
@@ -1,5 +1,6 @@
 task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
+    //noinspection GrDeprecatedAPIUsage
+    classifier = 'sources'
     from android.sourceSets.main.java.source
 }
 

--- a/android/ui/build.gradle
+++ b/android/ui/build.gradle
@@ -11,7 +11,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = '1.8'
         useIR = true
     }
     buildFeatures {

--- a/android/ui/build.gradle
+++ b/android/ui/build.gradle
@@ -33,3 +33,9 @@ dependencies {
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.ui:ui-tooling:$compose_version"
 }
+
+ext {
+    PUBLISH_ARTIFACT_ID = 'ui-android'
+}
+
+apply from: "${rootProject.projectDir}/scripts/maven.gradle"


### PR DESCRIPTION
The latest artifacts [can be found on Maven Central](https://search.maven.org/search?q=g:com.trafi.maas).

To publish, specify the following properties / environment variables

```
signing.keyId / MAVEN_SIGNING_KEY_ID
signing.password / MAVEN_SIGNING_KEY_PASSOWRD
signing.secretKeyRingFile / MAVEN_SIGNING_KEY_RING_FILE
sonatypeUsername / SONATYPE_USERNAME
sonatypePassword / SONATYPE_PASSWORD
```

Useful resources for setting up publishing:
- [AGP maven-publish plugin integration](https://developer.android.com/studio/build/maven-publish-plugin)
- [Sonatype's guide for publishing to OSSRH](https://central.sonatype.org/pages/ossrh-guide.html#deployment)
- [sample script by Chris Banes](https://github.com/chrisbanes/gradle-mvn-push)
- [detailed community guide](https://blog.autsoft.hu/publishing-an-android-library-to-mavencentral-in-2019/)

OkHttp has a good resource about [prerequisites for releasing to Sonatype's Maven Central repository](https://square.github.io/okhttp/releasing/) including obtaining the properties mentioned above. Glide has a good resource about [SNAPSHOT dependencies](https://bumptech.github.io/glide/dev/snapshots.html).