### PR TITLE
Add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # MaaS Components
 
-[![Build Android](https://github.com/trafi/maas-components/workflows/Build%20Android/badge.svg?event=push)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22Build+Android%22)
-
-[![iOS tests](https://github.com/trafi/maas-components/workflows/iOS%20tests/badge.svg)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22iOS+tests%22)
+[![Android build](https://img.shields.io/github/workflow/status/trafi/maas-components/Build%20Android?event=push&logo=android)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22Build+Android%22)
+[![iOS tests](https://img.shields.io/github/workflow/status/trafi/maas-components/iOS%20tests?label=tests&logo=iOS)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22iOS+tests%22)
 
 *Work in progress, not ready for use in production.*
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Android build](https://img.shields.io/github/workflow/status/trafi/maas-components/Build%20Android?event=push&logo=android)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22Build+Android%22)
 [![iOS tests](https://img.shields.io/github/workflow/status/trafi/maas-components/iOS%20tests?label=tests&logo=iOS)](https://github.com/trafi/maas-components/actions?query=workflow%3A%22iOS+tests%22)
+[![Maven Central](https://img.shields.io/maven-central/v/com.trafi.maas/routes-ui-android?logo=android)](https://search.maven.org/search?q=g:com.trafi.maas)
+[![Swift Package Manager](https://img.shields.io/github/v/release/trafi/maas-components?include_prereleases&label=SPM&logo=iOS)](https://github.com/trafi/maas-components/releases)
 
 *Work in progress, not ready for use in production.*
 


### PR DESCRIPTION
Using [shields.io](http://shields.io).

Unfortunately, we don't currently have an umbrella artifact for all dependencies, i.e. `locations-android`, `routes-ui-android`, etc. Using the `routes-ui-android` artifact for versioning for now.