### PR TITLE
Analytics in common:core module

### DIFF
--- a/android/routes/ui/src/main/java/com/trafi/routes/ui/RoutesResult.kt
+++ b/android/routes/ui/src/main/java/com/trafi/routes/ui/RoutesResult.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.ui.tooling.preview.Preview
+import com.trafi.analytics.Analytics
+import com.trafi.analytics.AnalyticsEvent
 import com.trafi.core.model.Route
 import com.trafi.core.model.RoutesResult
 import com.trafi.core.model.mockResult
@@ -18,7 +20,15 @@ fun RoutesResult(
     modifier: Modifier = Modifier
 ) {
     LazyColumnFor(result.routes, modifier) { route ->
-        Route(route, onClick = { onRouteClick(route) }, modifier = Modifier.fillParentMaxWidth())
+        Route(route, onClick = {
+            Analytics.consume(
+                AnalyticsEvent.routeTap(
+                    routeResultId = result.id,
+                    routeId = route.id
+                )
+            )
+            onRouteClick(route)
+        }, modifier = Modifier.fillParentMaxWidth())
         if (result.routes.indexOf(route) != result.routes.lastIndex) {
             Divider(
                 modifier = Modifier

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -82,6 +82,21 @@ android {
 
 apply(from = "../../android/scripts/maven-meta.gradle")
 
+val mammoth by tasks.registering(JavaExec::class) {
+    group = "analytics"
+    val outputPath = project.file("src/commonMain/kotlin/com/trafi/analytics")
+    outputs.dir(outputPath)
+    outputs.upToDateWhen { false }
+
+    main = "-jar"
+    args(
+        "mammoth-kt-2.0.jar",
+        "--project", "open-sdk",
+        "--output-path", outputPath.path,
+        "--output-filename", "AnalyticsEvent.kt"
+    )
+}
+
 val xcframeworkPath = "build/bin/xcframework/MaasCore.xcframework"
 
 val cleanXcframework by tasks.creating(Exec::class) {

--- a/common/core/src/commonMain/kotlin/com/trafi/analytics/Analytics.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/analytics/Analytics.kt
@@ -1,0 +1,31 @@
+package com.trafi.analytics
+
+import kotlin.native.concurrent.ThreadLocal
+
+interface AnalyticsDelegate {
+    fun dispatchEvent(event: Analytics.Event)
+
+    val screenName: String?
+    val modalName: String?
+}
+
+@ThreadLocal
+object Analytics {
+
+    private var delegate: AnalyticsDelegate? = null
+
+    val screenName: String get() = delegate?.screenName ?: ""
+    val modalName: String get() = delegate?.modalName ?: ""
+
+    fun consume(event: Event) {
+        delegate?.dispatchEvent(event)
+    }
+
+    fun set(delegate: AnalyticsDelegate) {
+        this.delegate = delegate
+    }
+
+    data class Event(val business: RawEvent?, val publish: RawEvent)
+}
+
+data class RawEvent(val name: String, val parameters: Map<String, String>)

--- a/common/core/src/commonMain/kotlin/com/trafi/analytics/AnalyticsEvent.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/analytics/AnalyticsEvent.kt
@@ -1,0 +1,55 @@
+// open-sdk schema version 2
+// Generated with https://github.com/trafi/mammoth-kt
+// Do not edit manually.
+package com.trafi.analytics
+
+import kotlin.String
+
+private const val mammothSchemaVersion: String = "2"
+
+object AnalyticsEvent {
+    /**
+     * Tap on a specific route
+     *
+     * @param routeResultId Route search result id
+     * @param routeId Route id
+     * @param screenName Name of the active screen
+     */
+    fun routeTap(
+        routeResultId: String,
+        routeId: String,
+        screenName: String = Analytics.screenName
+    ): Analytics.Event = Analytics.Event(
+        business = RawEvent(
+            name = "RouteTap",
+            parameters = mapOf(
+                "event_type" to "element_tap",
+                "object_name" to "Route",
+                "screen_name" to screenName,
+                "route_result_id" to routeResultId,
+                "route_id" to routeId,
+                "schema_event_id" to "765",
+                "schema_version" to mammothSchemaVersion
+            )
+        ),
+        publish = RawEvent(
+            name = "element_tap",
+            parameters = mapOf(
+                "content" to "Route",
+                "screen_name" to screenName,
+                "group_id" to routeResultId,
+                "item_id" to routeId,
+                "achievement_id" to "765",
+                "score" to mammothSchemaVersion
+            )
+        )
+    )
+}
+
+enum class EventType(
+    val value: String
+) {
+    SCREEN_OPEN("screen_open"),
+
+    ELEMENT_TAP("element_tap");
+}


### PR DESCRIPTION
Those with access to Trafi's internal VPN can [access & edit the event schema via the Mammoth editor](https://mammoth.trafi.com/open-sdk/events).

Uses https://github.com/trafi/mammoth-kt to generate type-safe analytics events from the schema.

Any UI component can call `Analytics.consume(AnalyticsEvent.$eventName())`. By default, events go nowhere. Any SDK consumer can register an `AnalyticsDelegate` to do something with the events.

```kotlin
class PrintAnalyticsToConsole : AnalyticsDelegate {
  fun dispatchEvent(event: Analytics.Event) {
    println(event.business.name)
  }

  val screenName: String? get() = null
  val modalName: String? get() = null
}

Analytics.set(PrintAnalyticsToConsole())
```