### PR TITLE
Current theme in common:core module

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
 }
 apply from: "${rootProject.projectDir}/scripts/resolve-property.gradle"
 
@@ -44,10 +43,6 @@ android {
         kotlinCompilerVersion kotlin_version
         kotlinCompilerExtensionVersion compose_version
     }
-}
-
-androidExtensions {
-    features = ["parcelize"]
 }
 
 dependencies {

--- a/android/ui/src/main/java/com/trafi/ui/theme/CurrentTheme.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/CurrentTheme.kt
@@ -1,0 +1,63 @@
+package com.trafi.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import com.trafi.ui.theme.internal.CurrentColorPalette
+import com.trafi.ui.theme.internal.CurrentCornerRadiusScale
+import com.trafi.ui.theme.internal.CurrentSpacingScale
+import com.trafi.ui.theme.internal.CurrentTheme
+import com.trafi.ui.theme.internal.CurrentTypographyScale
+
+@Composable
+internal val currentTheme: CurrentTheme
+    get() {
+        val colors = MaasTheme.colors
+        val typography = MaasTheme.typography
+        val spacing = MaasTheme.spacing
+        val cornerRadius = MaasTheme.cornerRadius
+        return CurrentTheme(
+            colorPalette = with(colors) {
+                CurrentColorPalette(
+                    primary = primary.osColor,
+                    primaryVariant = primaryVariant.osColor,
+                    secondary = secondary.osColor,
+                    secondaryVariant = secondaryVariant.osColor,
+                    background = background.osColor,
+                    surface = surface.osColor,
+                    error = error.osColor,
+                    onPrimary = onPrimary.osColor,
+                    onSecondary = onSecondary.osColor,
+                    onBackground = onBackground.osColor,
+                    onSurface = onSurface.osColor,
+                    onError = onError.osColor,
+                )
+            },
+            typographyScale = with(typography) {
+                CurrentTypographyScale(
+                    headingXXL = headingXXL,
+                    headingXL = headingXL,
+                    headingL = headingL,
+                    headingM = headingM,
+                    textL = textL,
+                    textM = textM,
+                    textS = textS,
+                    label = label,
+                )
+            },
+            spacingScale = with(spacing) {
+                CurrentSpacingScale(
+                    globalMargin = globalMargin.osDimension
+                )
+            },
+            cornerRadiusScale = with(cornerRadius) {
+                CurrentCornerRadiusScale(
+                    buttonRadius = buttonRadius.osDimension
+                )
+            },
+        )
+    }
+
+private val Color.osColor: Long get() = toArgb().toLong()
+private val Dp.osDimension: Float get() = value

--- a/android/ui/src/main/java/com/trafi/ui/theme/Typography.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/Typography.kt
@@ -3,15 +3,10 @@ package com.trafi.ui.theme
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.font
 import androidx.compose.ui.text.font.fontFamily
-import androidx.compose.ui.unit.sp
 import com.trafi.ui.R
-import com.trafi.ui.theme.internal.BasicFontStyle
-import com.trafi.ui.theme.internal.BasicFontWeight
-import com.trafi.ui.theme.internal.BasicTextStyle
 import com.trafi.ui.theme.internal.TypographyScale
 
 internal val Inter = fontFamily(
@@ -33,14 +28,14 @@ data class MaasTypography internal constructor(
 ) {
     constructor(
         defaultFontFamily: FontFamily = Inter,
-        headingXXL: TextStyle = TypographyScale.headingXXL.toTextStyle(),
-        headingXL: TextStyle = TypographyScale.headingXL.toTextStyle(),
-        headingL: TextStyle = TypographyScale.headingL.toTextStyle(),
-        headingM: TextStyle = TypographyScale.headingM.toTextStyle(),
-        textL: TextStyle = TypographyScale.textL.toTextStyle(),
-        textM: TextStyle = TypographyScale.textM.toTextStyle(),
-        textS: TextStyle = TypographyScale.textS.toTextStyle(),
-        label: TextStyle = TypographyScale.label.toTextStyle(),
+        headingXXL: TextStyle = TypographyScale.headingXXL,
+        headingXL: TextStyle = TypographyScale.headingXL,
+        headingL: TextStyle = TypographyScale.headingL,
+        headingM: TextStyle = TypographyScale.headingM,
+        textL: TextStyle = TypographyScale.textL,
+        textM: TextStyle = TypographyScale.textM,
+        textS: TextStyle = TypographyScale.textS,
+        label: TextStyle = TypographyScale.label,
     ) : this(
         headingXXL = headingXXL.withDefaultFontFamily(defaultFontFamily),
         headingXL = headingXL.withDefaultFontFamily(defaultFontFamily),
@@ -56,17 +51,3 @@ data class MaasTypography internal constructor(
 private fun TextStyle.withDefaultFontFamily(default: FontFamily): TextStyle {
     return if (fontFamily != null) this else copy(fontFamily = default)
 }
-
-private fun BasicTextStyle.toTextStyle(): TextStyle = TextStyle(
-    fontStyle = when (fontStyle) {
-        BasicFontStyle.Normal -> FontStyle.Normal
-        BasicFontStyle.Italic -> FontStyle.Italic
-    },
-    fontWeight = when (fontWeight) {
-        BasicFontWeight.Normal -> FontWeight.Normal
-        BasicFontWeight.SemiBold -> FontWeight.SemiBold
-        BasicFontWeight.Bold -> FontWeight.Bold
-    },
-    fontSize = fontSize.sp,
-    lineHeight = lineHeight.sp
-)

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 group = "com.trafi.maas"
 version = rootProject.version
 
+val composeVersion = "1.0.0-alpha08"
 val ktorVersion = "1.4.1"
 val serializationVersion = "1.0.1"
 val coroutinesVersion = "1.4.1-native-mt"
@@ -22,6 +23,12 @@ repositories {
 kotlin {
     android {
         publishAllLibraryVariants()
+        compilations.all {
+            kotlinOptions {
+                jvmTarget = "1.8"
+                useIR = true
+            }
+        }
     }
     ios {
         binaries {
@@ -48,6 +55,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-android:$ktorVersion")
+                implementation("androidx.compose.ui:ui:$composeVersion")
             }
         }
         val androidTest by getting {

--- a/common/core/src/androidMain/kotlin/com/trafi/shared/Platform.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/shared/Platform.kt
@@ -1,5 +1,0 @@
-package com.trafi.shared
-
-actual class Platform actual constructor() {
-    actual val platform: String = "Android ${android.os.Build.VERSION.SDK_INT}"
-}

--- a/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
@@ -7,48 +7,37 @@ import androidx.compose.ui.unit.sp
 
 actual typealias OsTextStyle = TextStyle
 
-actual fun OsTextStyle.copy(
+internal actual fun OsTextStyle.copy(
     fontStyle: BasicFontStyle?,
     fontWeight: BasicFontWeight?,
     fontSize: Int?,
     lineHeight: Int?,
-): OsTextStyle {
-    val basic = toBasicTextStyle()
-    return merge(
-        BasicTextStyle(
-            fontStyle = fontStyle ?: basic.fontStyle,
-            fontWeight = fontWeight ?: basic.fontWeight,
-            fontSize = fontSize ?: basic.fontSize,
-            lineHeight = lineHeight ?: basic.lineHeight,
-        ).toTextStyle()
-    )
-}
-
-private fun OsTextStyle.toBasicTextStyle(): BasicTextStyle = BasicTextStyle(
-    fontStyle = when (fontStyle) {
-        FontStyle.Normal, null -> BasicFontStyle.Normal
-        FontStyle.Italic -> BasicFontStyle.Italic
-    },
-    fontWeight = when (fontWeight?.weight) {
-        FontWeight.Normal.weight, null -> BasicFontWeight.Normal
-        FontWeight.SemiBold.weight -> BasicFontWeight.SemiBold
-        FontWeight.Bold.weight -> BasicFontWeight.Bold
-        else -> BasicFontWeight.Normal
-    },
-    fontSize = fontSize.value.toInt(),
-    lineHeight = lineHeight.value.toInt(),
+): OsTextStyle = copy(
+    fontStyle = fontStyle?.os ?: this.fontStyle,
+    fontWeight = fontWeight?.os ?: this.fontWeight,
+    fontSize = fontSize?.sp ?: this.fontSize,
+    lineHeight = lineHeight?.sp ?: this.lineHeight
 )
 
-private fun BasicTextStyle.toTextStyle(): TextStyle = TextStyle(
-    fontStyle = when (fontStyle) {
-        BasicFontStyle.Normal -> FontStyle.Normal
-        BasicFontStyle.Italic -> FontStyle.Italic
-    },
-    fontWeight = when (fontWeight) {
-        BasicFontWeight.Normal -> FontWeight.Normal
-        BasicFontWeight.SemiBold -> FontWeight.SemiBold
-        BasicFontWeight.Bold -> FontWeight.Bold
-    },
+internal actual fun OsTextStyle(
+    fontStyle: BasicFontStyle,
+    fontWeight: BasicFontWeight,
+    fontSize: Int,
+    lineHeight: Int,
+): OsTextStyle = TextStyle(
+    fontStyle = fontStyle.os,
+    fontWeight = fontWeight.os,
     fontSize = fontSize.sp,
     lineHeight = lineHeight.sp
 )
+
+private val BasicFontStyle.os get() = when (this) {
+    BasicFontStyle.Normal -> FontStyle.Normal
+    BasicFontStyle.Italic -> FontStyle.Italic
+}
+
+private val BasicFontWeight.os get() = when (this) {
+    BasicFontWeight.Normal -> FontWeight.Normal
+    BasicFontWeight.SemiBold -> FontWeight.SemiBold
+    BasicFontWeight.Bold -> FontWeight.Bold
+}

--- a/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
@@ -1,0 +1,54 @@
+package com.trafi.ui.theme.internal
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+actual typealias OsTextStyle = TextStyle
+
+actual fun OsTextStyle.copy(
+    fontStyle: BasicFontStyle?,
+    fontWeight: BasicFontWeight?,
+    fontSize: Int?,
+    lineHeight: Int?,
+): OsTextStyle {
+    val basic = toBasicTextStyle()
+    return merge(
+        BasicTextStyle(
+            fontStyle = fontStyle ?: basic.fontStyle,
+            fontWeight = fontWeight ?: basic.fontWeight,
+            fontSize = fontSize ?: basic.fontSize,
+            lineHeight = lineHeight ?: basic.lineHeight,
+        ).toTextStyle()
+    )
+}
+
+private fun OsTextStyle.toBasicTextStyle(): BasicTextStyle = BasicTextStyle(
+    fontStyle = when (fontStyle) {
+        FontStyle.Normal, null -> BasicFontStyle.Normal
+        FontStyle.Italic -> BasicFontStyle.Italic
+    },
+    fontWeight = when (fontWeight?.weight) {
+        FontWeight.Normal.weight, null -> BasicFontWeight.Normal
+        FontWeight.SemiBold.weight -> BasicFontWeight.SemiBold
+        FontWeight.Bold.weight -> BasicFontWeight.Bold
+        else -> BasicFontWeight.Normal
+    },
+    fontSize = fontSize.value.toInt(),
+    lineHeight = lineHeight.value.toInt(),
+)
+
+private fun BasicTextStyle.toTextStyle(): TextStyle = TextStyle(
+    fontStyle = when (fontStyle) {
+        BasicFontStyle.Normal -> FontStyle.Normal
+        BasicFontStyle.Italic -> FontStyle.Italic
+    },
+    fontWeight = when (fontWeight) {
+        BasicFontWeight.Normal -> FontWeight.Normal
+        BasicFontWeight.SemiBold -> FontWeight.SemiBold
+        BasicFontWeight.Bold -> FontWeight.Bold
+    },
+    fontSize = fontSize.sp,
+    lineHeight = lineHeight.sp
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/shared/Greeting.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/shared/Greeting.kt
@@ -1,8 +1,0 @@
-package com.trafi.shared
-
-
-class Greeting {
-    fun greeting(): String {
-        return "Hello, ${Platform().platform}!"
-    }
-}

--- a/common/core/src/commonMain/kotlin/com/trafi/shared/Platform.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/shared/Platform.kt
@@ -1,5 +1,0 @@
-package com.trafi.shared
-
-expect class Platform() {
-    val platform: String
-}

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentColorPalette.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentColorPalette.kt
@@ -1,0 +1,16 @@
+package com.trafi.ui.theme.internal
+
+class CurrentColorPalette(
+    val primary: OsColor,
+    val primaryVariant: OsColor,
+    val secondary: OsColor,
+    val secondaryVariant: OsColor,
+    val background: OsColor,
+    val surface: OsColor,
+    val error: OsColor,
+    val onPrimary: OsColor,
+    val onSecondary: OsColor,
+    val onBackground: OsColor,
+    val onSurface: OsColor,
+    val onError: OsColor,
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentCornerRadiusScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentCornerRadiusScale.kt
@@ -1,0 +1,5 @@
+package com.trafi.ui.theme.internal
+
+class CurrentCornerRadiusScale(
+    val buttonRadius: OsDimension,
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentSpacingScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentSpacingScale.kt
@@ -1,0 +1,5 @@
+package com.trafi.ui.theme.internal
+
+class CurrentSpacingScale(
+    val globalMargin: OsDimension,
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTheme.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTheme.kt
@@ -1,0 +1,8 @@
+package com.trafi.ui.theme.internal
+
+class CurrentTheme(
+    val colorPalette: CurrentColorPalette,
+    val typographyScale: CurrentTypographyScale,
+    val spacingScale: CurrentSpacingScale,
+    val cornerRadiusScale: CurrentCornerRadiusScale,
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTypographyScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTypographyScale.kt
@@ -1,0 +1,12 @@
+package com.trafi.ui.theme.internal
+
+class CurrentTypographyScale(
+    val headingXXL: OsTextStyle,
+    val headingXL: OsTextStyle,
+    val headingL: OsTextStyle,
+    val headingM: OsTextStyle,
+    val textL: OsTextStyle,
+    val textM: OsTextStyle,
+    val textS: OsTextStyle,
+    val label: OsTextStyle,
+)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
@@ -2,28 +2,21 @@ package com.trafi.ui.theme.internal
 
 internal const val infinity = Float.POSITIVE_INFINITY
 
-internal fun textStyle(builder: BasicTextStyle.Builder.() -> Unit): BasicTextStyle =
-    BasicTextStyle.Builder().apply(builder).build()
+internal fun textStyle(builder: TextStyleBuilder.() -> Unit): OsTextStyle =
+    TextStyleBuilder().apply(builder).build()
 
-data class BasicTextStyle(
-    val fontStyle: BasicFontStyle,
-    val fontWeight: BasicFontWeight,
-    val fontSize: Int,
-    val lineHeight: Int
+internal class TextStyleBuilder(
+    var fontStyle: BasicFontStyle = BasicFontStyle.Normal,
+    var fontWeight: BasicFontWeight = BasicFontWeight.Normal,
+    var fontSize: Int? = null,
+    var lineHeight: Int? = null,
 ) {
-    internal class Builder(
-        var fontStyle: BasicFontStyle = BasicFontStyle.Normal,
-        var fontWeight: BasicFontWeight = BasicFontWeight.Normal,
-        var fontSize: Int? = null,
-        var lineHeight: Int? = null,
-    ) {
-        fun build(): BasicTextStyle = BasicTextStyle(
-            fontStyle = fontStyle,
-            fontWeight = fontWeight,
-            fontSize = requireNotNull(fontSize),
-            lineHeight = requireNotNull(lineHeight),
-        )
-    }
+    fun build(): OsTextStyle = OsTextStyle(
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontSize = requireNotNull(fontSize),
+        lineHeight = requireNotNull(lineHeight),
+    )
 }
 
 enum class BasicFontStyle {

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsColor.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsColor.kt
@@ -1,0 +1,3 @@
+package com.trafi.ui.theme.internal
+
+typealias OsColor = Long

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsDimension.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsDimension.kt
@@ -1,0 +1,3 @@
+package com.trafi.ui.theme.internal
+
+typealias OsDimension = Float

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
@@ -1,0 +1,10 @@
+package com.trafi.ui.theme.internal
+
+expect class OsTextStyle
+
+expect fun OsTextStyle.copy(
+    fontStyle: BasicFontStyle? = null,
+    fontWeight: BasicFontWeight? = null,
+    fontSize: Int? = null,
+    lineHeight: Int? = null,
+): OsTextStyle

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
@@ -2,9 +2,16 @@ package com.trafi.ui.theme.internal
 
 expect class OsTextStyle
 
-expect fun OsTextStyle.copy(
+internal expect fun OsTextStyle.copy(
     fontStyle: BasicFontStyle? = null,
     fontWeight: BasicFontWeight? = null,
     fontSize: Int? = null,
     lineHeight: Int? = null,
+): OsTextStyle
+
+internal expect fun OsTextStyle(
+    fontStyle: BasicFontStyle,
+    fontWeight: BasicFontWeight,
+    fontSize: Int,
+    lineHeight: Int,
 ): OsTextStyle

--- a/common/core/src/iosMain/kotlin/com/trafi/shared/Platform.kt
+++ b/common/core/src/iosMain/kotlin/com/trafi/shared/Platform.kt
@@ -1,8 +1,0 @@
-package com.trafi.shared
-
-
-import platform.UIKit.UIDevice
-
-actual class Platform actual constructor() {
-    actual val platform: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
-}

--- a/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
+++ b/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/OsTextStyle.kt
@@ -1,0 +1,37 @@
+package com.trafi.ui.theme.internal
+
+actual class OsTextStyle constructor(var font: UIFont, var lineSpacing: CGFloat) {
+    actual var basic: BasicTextStyle
+        get() = textStyle {
+            fontWeight = basicFontWeight()
+            fontSize = font.pointSize.toInt()
+            lineHeight = (font.lineHeight + lineSpacing).toInt()
+        }
+        set(value) {
+            lineSpacing = value.lineHeight.toDouble() - font.lineHeight
+            font = UIFont.fontWithDescriptor(
+                font.fontDescriptor.fontDescriptorByAddingAttributes(mapOf(UIFontDescriptorTraitsAttribute to mapOf(UIFontWeightTrait to fontWeight(value.fontWeight)))),
+                value.fontSize.toDouble()
+            )
+        }
+
+    private fun basicFontWeight(): BasicFontWeight {
+
+        val traits = font.fontDescriptor.objectForKey(UIFontDescriptorTraitsAttribute) as Map<Any?, *>
+        val weight = traits[UIFontWeightTrait] as NSNumber
+
+        return when(weight.doubleValue) {
+            UIFontWeightSemibold -> BasicFontWeight.SemiBold
+            UIFontWeightBold -> BasicFontWeight.Bold
+            else -> BasicFontWeight.Normal
+        }
+    }
+
+    private fun fontWeight(basicFontWeight: BasicFontWeight): UIFontWeight {
+        return when(basicFontWeight) {
+            BasicFontWeight.Normal -> UIFontWeightRegular
+            BasicFontWeight.SemiBold -> UIFontWeightSemibold
+            BasicFontWeight.Bold ->  UIFontWeightBold
+        }
+    }
+}

--- a/ios/Sources/MaaSTheme/Colors.swift
+++ b/ios/Sources/MaaSTheme/Colors.swift
@@ -2,95 +2,161 @@ import SwiftUI
 import UIKit
 import MaasCore
 
-extension Color {
+private enum ColorKeys {
 
-    // Shades
-    static var gray100: Color { .init(.gray100) }
-    static var gray200: Color { .init(.gray200) }
-    static var gray300: Color { .init(.gray300) }
-    static var gray400: Color { .init(.gray400) }
-    static var gray500: Color { .init(.gray500) }
-    static var gray600: Color { .init(.gray600) }
-    static var gray700: Color { .init(.gray700) }
-    static var gray800: Color { .init(.gray800) }
-    static var gray900: Color { .init(.gray900) }
+    static let L = ColorPalette.DefaultLight()
+    static let D = ColorPalette.DefaultDark()
 
-    // Light
-    static var primaryLight: Color { .init(.primaryLight) }
-    static var primaryVariantLight: Color { .init(.primaryVariantLight) }
-    static var secondaryLight: Color { .init(.secondaryLight) }
-    static var secondaryVariantLight: Color { .init(.secondaryVariantLight) }
-    static var backgroundLight: Color { .init(.backgroundLight) }
-    static var surfaceLight: Color { .init(.surfaceLight) }
-    static var errorLight: Color { .init(.errorLight) }
-    static var onPrimaryLight: Color { .init(.onPrimaryLight) }
-    static var onSecondaryLight: Color { .init(.onSecondaryLight) }
-    static var onBackgroundLight: Color { .init(.onBackgroundLight) }
-    static var onSurfaceLight: Color { .init(.onSurfaceLight) }
-    static var onErrorLight: Color { .init(.onErrorLight) }
+    static func dynamic(light: Int64, dark: Int64) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark ?
+                dark.uiColor :
+                light.uiColor
+        }
+    }
 
-    // Dark
-    static var primaryDark: Color { .init(.primaryDark) }
-    static var primaryVariantDark: Color { .init(.primaryVariantDark) }
-    static var secondaryDark: Color { .init(.secondaryDark) }
-    static var secondaryVariantDark: Color { .init(.secondaryVariantDark) }
-    static var backgroundDark: Color { .init(.backgroundDark) }
-    static var surfaceDark: Color { .init(.surfaceDark) }
-    static var errorDark: Color { .init(.errorDark) }
-    static var onPrimaryDark: Color { .init(.onPrimaryDark) }
-    static var onSecondaryDark: Color { .init(.onSecondaryDark) }
-    static var onBackgroundDark: Color { .init(.onBackgroundDark) }
-    static var onSurfaceDark: Color { .init(.onSurfaceDark) }
-    static var onErrorDark: Color { .init(.onErrorDark) }
+    struct Primary: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.Primary, dark: D.Primary) }
+    }
+    struct OnPrimary: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.OnPrimary, dark: D.OnPrimary) }
+    }
+    struct PrimaryVariant: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.PrimaryVariant, dark: D.PrimaryVariant) }
+    }
+    struct Secondary: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.Secondary, dark: D.Secondary) }
+    }
+    struct OnSecondary: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.OnSecondary, dark: D.OnSecondary) }
+    }
+    struct SecondaryVariant: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.SecondaryVariant, dark: D.SecondaryVariant) }
+    }
+    struct Background: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.Background, dark: D.Background) }
+    }
+    struct OnBackground: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.OnBackground, dark: D.OnBackground) }
+    }
+    struct Surface: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.Surface, dark: D.Surface) }
+    }
+    struct OnSurface: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.OnSurface, dark: D.OnSurface) }
+    }
+    struct Error: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.Error, dark: D.Error) }
+    }
+    struct OnError: EnvironmentKey {
+        static var defaultValue: UIColor { dynamic(light: L.OnError, dark: D.OnError) }
+    }
+}
+
+public extension EnvironmentValues {
+
+    var colorPrimary: Color { Color(uiColorPrimary) }
+    var uiColorPrimary: UIColor {
+        get { self[ColorKeys.Primary.self] }
+        set { self[ColorKeys.Primary.self] = newValue }
+    }
+    var colorOnPrimary: Color { Color(uiColorOnPrimary) }
+    var uiColorOnPrimary: UIColor {
+        get { self[ColorKeys.OnPrimary.self] }
+        set { self[ColorKeys.OnPrimary.self] = newValue }
+    }
+    var colorPrimaryVariant: Color { Color(uiColorPrimaryVariant) }
+    var uiColorPrimaryVariant: UIColor {
+        get { self[ColorKeys.PrimaryVariant.self] }
+        set { self[ColorKeys.PrimaryVariant.self] = newValue }
+    }
+    var colorSecondary: Color { Color(uiColorSecondary) }
+    var uiColorSecondary: UIColor {
+        get { self[ColorKeys.Secondary.self] }
+        set { self[ColorKeys.Secondary.self] = newValue }
+    }
+    var colorOnSecondary: Color { Color(uiColorOnSecondary) }
+    var uiColorOnSecondary: UIColor {
+        get { self[ColorKeys.OnSecondary.self] }
+        set { self[ColorKeys.OnSecondary.self] = newValue }
+    }
+    var colorSecondaryVariant: Color { Color(uiColorSecondaryVariant) }
+    var uiColorSecondaryVariant: UIColor {
+        get { self[ColorKeys.SecondaryVariant.self] }
+        set { self[ColorKeys.SecondaryVariant.self] = newValue }
+    }
+    var colorBackground: Color { Color(uiColorBackground) }
+    var uiColorBackground: UIColor {
+        get { self[ColorKeys.Background.self] }
+        set { self[ColorKeys.Background.self] = newValue }
+    }
+    var colorOnBackground: Color { Color(uiColorOnBackground) }
+    var uiColorOnBackground: UIColor {
+        get { self[ColorKeys.OnBackground.self] }
+        set { self[ColorKeys.OnBackground.self] = newValue }
+    }
+    var colorSurface: Color { Color(uiColorSurface) }
+    var uiColorSurface: UIColor {
+        get { self[ColorKeys.Surface.self] }
+        set { self[ColorKeys.Surface.self] = newValue }
+    }
+    var colorOnSurface: Color { Color(uiColorOnSurface) }
+    var uiColorOnSurface: UIColor {
+        get { self[ColorKeys.OnSurface.self] }
+        set { self[ColorKeys.OnSurface.self] = newValue }
+    }
+    var colorError: Color { Color(uiColorError) }
+    var uiColorError: UIColor {
+        get { self[ColorKeys.Error.self] }
+        set { self[ColorKeys.Error.self] = newValue }
+    }
+    var colorOnError: Color { Color(uiColorOnError) }
+    var uiColorOnError: UIColor {
+        get { self[ColorKeys.OnError.self] }
+        set { self[ColorKeys.OnError.self] = newValue }
+    }
+}
+
+public extension Int64 {
+    var color: Color {
+        return Color(uiColor)
+    }
+
+    var uiColor: UIColor {
+        let a = CGFloat((self & 0xff000000) >> 24) / 255
+        let r = CGFloat((self & 0x00ff0000) >> 16) / 255
+        let g = CGFloat((self & 0x0000ff00) >> 8) / 255
+        let b = CGFloat((self & 0x000000ff)) / 255
+
+        return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
 }
 
 extension UIColor {
+    func i64(_ colorScheme: ColorScheme) -> Int64 {
 
-    // Shades
-    static var gray100: UIColor { .init(ColorPalette().Gray100) }
-    static var gray200: UIColor { .init(ColorPalette().Gray200) }
-    static var gray300: UIColor { .init(ColorPalette().Gray300) }
-    static var gray400: UIColor { .init(ColorPalette().Gray400) }
-    static var gray500: UIColor { .init(ColorPalette().Gray500) }
-    static var gray600: UIColor { .init(ColorPalette().Gray600) }
-    static var gray700: UIColor { .init(ColorPalette().Gray700) }
-    static var gray800: UIColor { .init(ColorPalette().Gray800) }
-    static var gray900: UIColor { .init(ColorPalette().Gray900) }
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
 
-    // Light
-    static var primaryLight: UIColor { .init(ColorPalette.DefaultLight().Primary) }
-    static var primaryVariantLight: UIColor { .init(ColorPalette.DefaultLight().PrimaryVariant) }
-    static var secondaryLight: UIColor { .init(ColorPalette.DefaultLight().Secondary) }
-    static var secondaryVariantLight: UIColor { .init(ColorPalette.DefaultLight().SecondaryVariant) }
-    static var backgroundLight: UIColor { .white }
-    static var surfaceLight: UIColor { .white }
-    static var errorLight: UIColor { .init(ColorPalette.DefaultLight().Error) }
-    static var onPrimaryLight: UIColor { .white }
-    static var onSecondaryLight: UIColor { .black }
-    static var onBackgroundLight: UIColor { .gray900 }
-    static var onSurfaceLight: UIColor { .gray900 }
-    static var onErrorLight: UIColor { .white }
+        let color = resolvedColor(with: UITraitCollection(userInterfaceStyle: colorScheme.interfaceStyle))
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
 
-    // Dark
-    static var primaryDark: UIColor { .init(ColorPalette.DefaultDark().Primary) }
-    static var primaryVariantDark: UIColor { .init(ColorPalette.DefaultDark().PrimaryVariant) }
-    static var secondaryDark: UIColor { .init(ColorPalette.DefaultDark().Secondary) }
-    static var secondaryVariantDark: UIColor { .init(ColorPalette.DefaultDark().SecondaryVariant) }
-    static var backgroundDark: UIColor { .black }
-    static var surfaceDark: UIColor { .black }
-    static var errorDark: UIColor { .init(ColorPalette.DefaultDark().Error) }
-    static var onPrimaryDark: UIColor { .white }
-    static var onSecondaryDark: UIColor { .black }
-    static var onBackgroundDark: UIColor { .white }
-    static var onSurfaceDark: UIColor { .white }
-    static var onErrorDark: UIColor { .white }
+        return (Int64)(a*255)<<24 | (Int64)(r*255)<<16 | (Int64)(g*255)<<8 | (Int64)(b*255)<<0
+    }
+}
 
-    convenience init(_ int64: Int64) {
-        let a = CGFloat((int64 & 0xff000000) >> 24) / 255.0
-        let r = CGFloat((int64 & 0x00ff0000) >> 16) / 255.0
-        let g = CGFloat((int64 & 0x0000ff00) >> 8) / 255.0
-        let b = CGFloat((int64 & 0x000000ff)) / 255.0
 
-        self.init(red: r, green: g, blue: b, alpha: a)
+private extension ColorScheme {
+    var interfaceStyle: UIUserInterfaceStyle {
+        switch self {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        @unknown default:
+            return .unspecified
+        }
     }
 }

--- a/ios/Sources/MaaSTheme/CornerRadius.swift
+++ b/ios/Sources/MaaSTheme/CornerRadius.swift
@@ -1,15 +1,39 @@
-import Foundation
+import SwiftUI
+import UIKit
 import MaasCore
+
+struct CornerRadiusButton: EnvironmentKey {
+    static var defaultValue: CGFloat { CornerRadiusScale.Default().ButtonRadius.cgFloat }
+}
+public extension EnvironmentValues {
+    var cornerRadiusButton: CGFloat {
+        get { self[CornerRadiusButton.self] }
+        set { self[CornerRadiusButton.self] = newValue }
+    }
+}
+
 
 public struct CornerRadius {
 
-    public let value: Double
+    public let value: CGFloat
 
-    public static var none: CornerRadius { .init(value: Double(CornerRadiusScale().none)) }
-    public static var xxs: CornerRadius { .init(value: Double(CornerRadiusScale().xxs)) }
-    public static var xs: CornerRadius { .init(value: Double(CornerRadiusScale().xs)) }
-    public static var sm: CornerRadius { .init(value: Double(CornerRadiusScale().sm)) }
-    public static var lg: CornerRadius { .init(value: Double(CornerRadiusScale().lg)) }
-    public static var xl: CornerRadius { .init(value: Double(CornerRadiusScale().xl)) }
-    public static var round: CornerRadius { .init(value: Double(CornerRadiusScale().round)) }
+    public static var none: CornerRadius { .init(value: CGFloat(CornerRadiusScale().none)) }
+    public static var xxs: CornerRadius { .init(value: CGFloat(CornerRadiusScale().xxs)) }
+    public static var xs: CornerRadius { .init(value: CGFloat(CornerRadiusScale().xs)) }
+    public static var sm: CornerRadius { .init(value: CGFloat(CornerRadiusScale().sm)) }
+    public static var lg: CornerRadius { .init(value: CGFloat(CornerRadiusScale().lg)) }
+    public static var xl: CornerRadius { .init(value: CGFloat(CornerRadiusScale().xl)) }
+    public static var round: CornerRadius { .init(value: CGFloat(CornerRadiusScale().round)) }
+}
+
+public extension Float {
+    public var cgFloat: CGFloat {
+        self == Float.infinity ? .greatestFiniteMagnitude : CGFloat(self)
+    }
+}
+
+public extension CGFloat {
+    public var float: Float {
+        self == CGFloat.greatestFiniteMagnitude ? Float.infinity : Float(self)
+    }
 }

--- a/ios/Sources/MaaSTheme/Theme.swift
+++ b/ios/Sources/MaaSTheme/Theme.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import UIKit
+import MaasCore
+
+public extension EnvironmentValues {
+
+    var currentTheme: CurrentTheme {
+        get {
+            CurrentTheme(
+                colorPalette: CurrentColorPalette(
+                    primary: uiColorPrimary.i64(colorScheme),
+                    primaryVariant: uiColorPrimaryVariant.i64(colorScheme),
+                    secondary: uiColorSecondary.i64(colorScheme),
+                    secondaryVariant: uiColorSecondaryVariant.i64(colorScheme),
+                    background: uiColorBackground.i64(colorScheme),
+                    surface: uiColorSurface.i64(colorScheme),
+                    error: uiColorError.i64(colorScheme),
+                    onPrimary: uiColorOnPrimary.i64(colorScheme),
+                    onSecondary: uiColorOnSecondary.i64(colorScheme),
+                    onBackground: uiColorOnBackground.i64(colorScheme),
+                    onSurface: uiColorOnSurface.i64(colorScheme),
+                    onError: uiColorOnError.i64(colorScheme)),
+                typographyScale: CurrentTypographyScale(
+                    headingXXL: uiFontHeadingXXL,
+                    headingXL: uiFontHeadingXL,
+                    headingL: uiFontHeadingL,
+                    headingM: uiFontHeadingM,
+                    textL: uiFontTextL,
+                    textM: uiFontTextM,
+                    textS: uiFontTextS,
+                    label: uiFontLabel
+                ),
+                spacingScale: CurrentSpacingScale(
+                    globalMargin: Float(SpacingScale.Default().GlobalMargin)
+                ),
+                cornerRadiusScale: CurrentCornerRadiusScale(
+                    buttonRadius: cornerRadiusButton.float)
+            )
+        }
+    }
+}

--- a/ios/Sources/MaaSTheme/Typography.swift
+++ b/ios/Sources/MaaSTheme/Typography.swift
@@ -1,186 +1,138 @@
 import MaasCore
 import SwiftUI
 
-public struct HeadingXXL: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().headingXXL.font
-    }
+struct HeadingXXL: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().headingXXL }
 }
-
-public struct HeadingXL: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().headingXL.font
-    }
+struct HeadingXL: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().headingXL }
 }
-
-public struct HeadingL: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().headingL.font
-    }
+struct HeadingL: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().headingL }
 }
-
-public struct HeadingM: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().headingM.font
-    }
+struct HeadingM: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().headingM }
 }
-
-public struct TextL: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().textL.font
-    }
+struct TextL: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().textL }
 }
-
-public struct TextM: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().textM.font
-    }
+struct TextM: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().textM }
 }
-
-public struct TextS: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().textS.font
-    }
+struct TextS: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().textS }
 }
-
-public struct Label: EnvironmentKey {
-    public static var defaultValue: Font {
-        TypographyScale().label.font
-    }
+struct Label: EnvironmentKey {
+    static var defaultValue: UIFont { TypographyScale().label }
 }
 
 public extension EnvironmentValues {
 
-    var fontHeadingXXL: Font {
-        get { self[HeadingXXL.self] }
+    var fontHeadingXXL: Font { Font(uiFontHeadingXXL) }
+    var uiFontHeadingXXL: UIFont {
+        get { self[HeadingXXL.self].scaled(sizeCategory) }
         set { self[HeadingXXL.self] = newValue }
     }
 
-    var fontHeadingXL: Font {
-        get { self[HeadingXL.self] }
+    var fontHeadingXL: Font { Font(uiFontHeadingXL) }
+    var uiFontHeadingXL: UIFont {
+        get { self[HeadingXL.self].scaled(sizeCategory) }
         set { self[HeadingXL.self] = newValue }
     }
 
-    var fontHeadingL: Font {
-        get { self[HeadingL.self] }
+    var fontHeadingL: Font { Font(uiFontHeadingL) }
+    var uiFontHeadingL: UIFont {
+        get { self[HeadingL.self].scaled(sizeCategory) }
         set { self[HeadingL.self] = newValue }
     }
 
-    var fontHeadingM: Font {
-        get { self[HeadingM.self] }
+    var fontHeadingM: Font { Font(uiFontHeadingM) }
+    var uiFontHeadingM: UIFont {
+        get { self[HeadingM.self].scaled(sizeCategory) }
         set { self[HeadingM.self] = newValue }
     }
 
-    var fontTextL: Font {
-        get { self[TextL.self] }
+    var fontTextL: Font { Font(uiFontTextL) }
+    var uiFontTextL: UIFont {
+        get { self[TextL.self].scaled(sizeCategory) }
         set { self[TextL.self] = newValue }
     }
 
-    var fontTextM: Font {
-        get { self[TextM.self] }
+    var fontTextM: Font { Font(uiFontTextM) }
+    var uiFontTextM: UIFont {
+        get { self[TextM.self].scaled(sizeCategory) }
         set { self[TextM.self] = newValue }
     }
 
-    var fontTextS: Font {
-        get { self[TextS.self] }
+    var fontTextS: Font { Font(uiFontTextS) }
+    var uiFontTextS: UIFont {
+        get { self[TextS.self].scaled(sizeCategory) }
         set { self[TextS.self] = newValue }
     }
 
-    var fontLabel: Font {
-        get { self[Label.self] }
+    var fontLabel: Font { Font(uiFontLabel) }
+    var uiFontLabel: UIFont {
+        get { self[Label.self].scaled(sizeCategory) }
         set { self[Label.self] = newValue }
     }
 }
 
+extension UIFont {
 
-public extension Font {
+    func scaled(_ sizeCategory: ContentSizeCategory) -> UIFont {
 
-    static var headingXXL: Font {
-        TypographyScale().headingXXL.font
-    }
+        let textStyle: UIFont.TextStyle
 
-    static var headingXL: Font {
-        TypographyScale().headingXL.font
-    }
+        switch pointSize {
+        case 28...: textStyle = .title1
+        case 22...: textStyle = .title2
+        case 20...: textStyle = .title3
+        case 17...: textStyle = .body
+        case 16...: textStyle = .callout
+        case 15...: textStyle = .subheadline
+        case 13...: textStyle = .footnote
+        case 12...: textStyle = .caption1
+        default:    textStyle = .caption2
+        }
 
-    static var headingL: Font {
-        TypographyScale().headingL.font
-    }
-
-    static var headingM: Font {
-        TypographyScale().headingM.font
-    }
-
-    static var textL: Font {
-        TypographyScale().textL.font
-    }
-
-    static var textM: Font {
-        TypographyScale().textM.font
-    }
-
-    static var textS: Font {
-        TypographyScale().textS.font
-    }
-
-    static var label: Font {
-        TypographyScale().label.font
+        return self.withSize(pointSize * textStyle.scaleFactor(for: sizeCategory))
     }
 }
 
-extension BasicTextStyle {
-    var font: Font {
-        Font.system(
-            size: CGFloat(fontSize),
-            weight: fontWeight.weight,
-            design: .default)
+private extension UIFont.TextStyle {
+
+    func scaleFactor(for sizeCategory: ContentSizeCategory) -> CGFloat {
+
+        let medium = UIFont.preferredFont(
+            forTextStyle: self,
+            compatibleWith: UITraitCollection(preferredContentSizeCategory: .medium)
+        )
+
+        let scaled = UIFont.preferredFont(
+            forTextStyle: self,
+            compatibleWith: UITraitCollection(preferredContentSizeCategory: sizeCategory.ui)
+        )
+
+        return scaled.pointSize / medium.pointSize
     }
 }
 
-extension BasicFontWeight {
-    var weight: Font.Weight {
+private extension ContentSizeCategory {
+    var ui: UIContentSizeCategory {
         switch self {
-        case .normal: return .regular
-        case .semibold: return .semibold
-        case .bold: return .bold
-        default: return .regular
+        case .extraSmall: return .extraSmall
+        case .small: return .small
+        case .medium: return .medium
+        case .large: return .large
+        case .extraLarge: return .extraLarge
+        case .extraExtraLarge: return .extraExtraLarge
+        case .extraExtraExtraLarge: return .extraExtraExtraLarge
+        case .accessibilityMedium: return .accessibilityMedium
+        case .accessibilityLarge: return .accessibilityLarge
+        case .accessibilityExtraLarge: return .accessibilityExtraLarge
+        case .accessibilityExtraExtraLarge: return .accessibilityExtraExtraLarge
+        case .accessibilityExtraExtraExtraLarge: return .accessibilityExtraExtraExtraLarge
         }
     }
 }
 
-struct TypographyTextView: View {
-
-    var body: some View {
-        List {
-            Text(text)
-                .font(.headingXXL)
-            Text(text)
-                .font(.headingXL)
-            Text(text)
-                .font(.headingL)
-            Text(text)
-                .font(.headingM)
-            Text(text)
-                .font(.textL)
-            Text(text)
-                .font(.textM)
-            Text(text)
-                .font(.textS)
-            Text(text)
-                .font(.label)
-        }
-    }
-
-    let text = "Cultivate visionary integrated ecologies. Harness matrix and revolutionize world-class seamless target brand sexy infrastructures."
-}
-
-#if DEBUG
-struct TypographyTextView_Previews: PreviewProvider {
-    static var previews: some View {
-        TypographyTextView()
-            .environment(\.fontHeadingL, .headingL)
-            // .environment(\.theme, .myTheme)
-            .previewLayout(.sizeThatFits)
-    }
-}
-#endif


### PR DESCRIPTION
Enable Kotlin/Native code to be aware of and use values from the current theme. Enables theme-aware code to be shared across iOS & Android via Kotlin/Native; see #34 for an example. To enable bidirectional mapping, text styles in common:core are now declared using expect / actual and map directly to Compose `TextStyle` / iOS `UIFont`.

```kotlin
expect class OsTextStyle

// android
actual typealias OsTextStyle = TextStyle

// ios
actual typealias OsTextStyle = UIFont
```

cc @domasn 