### PR TITLE
Seamless theme types in Kotlin/Native

### DIFF
--- a/android/ui/src/main/java/com/trafi/ui/theme/Color.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/Color.kt
@@ -9,29 +9,29 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import com.trafi.ui.theme.internal.ColorPalette
 
-@Stable val Grey100 = Color(ColorPalette.Gray100)
-@Stable val Grey200 = Color(ColorPalette.Gray200)
-@Stable val Grey300 = Color(ColorPalette.Gray300)
-@Stable val Grey400 = Color(ColorPalette.Gray400)
-@Stable val Grey500 = Color(ColorPalette.Gray500)
-@Stable val Grey600 = Color(ColorPalette.Gray600)
-@Stable val Grey700 = Color(ColorPalette.Gray700)
-@Stable val Grey800 = Color(ColorPalette.Gray800)
-@Stable val Grey900 = Color(ColorPalette.Gray900)
+@Stable val Grey100 = ColorPalette.Gray100
+@Stable val Grey200 = ColorPalette.Gray200
+@Stable val Grey300 = ColorPalette.Gray300
+@Stable val Grey400 = ColorPalette.Gray400
+@Stable val Grey500 = ColorPalette.Gray500
+@Stable val Grey600 = ColorPalette.Gray600
+@Stable val Grey700 = ColorPalette.Gray700
+@Stable val Grey800 = ColorPalette.Gray800
+@Stable val Grey900 = ColorPalette.Gray900
 
 fun MaasTheme.lightColors(
-    primary: Color = Color(ColorPalette.DefaultLight.Primary),
-    primaryVariant: Color = Color(ColorPalette.DefaultLight.PrimaryVariant),
-    secondary: Color = Color(ColorPalette.DefaultLight.Secondary),
-    secondaryVariant: Color = Color(ColorPalette.DefaultLight.SecondaryVariant),
-    background: Color = Color(ColorPalette.DefaultLight.Background),
-    surface: Color = Color(ColorPalette.DefaultLight.Surface),
-    error: Color = Color(ColorPalette.DefaultLight.Error),
-    onPrimary: Color = Color(ColorPalette.DefaultLight.OnPrimary),
-    onSecondary: Color = Color(ColorPalette.DefaultLight.OnSecondary),
-    onBackground: Color = Color(ColorPalette.DefaultLight.OnBackground),
-    onSurface: Color = Color(ColorPalette.DefaultLight.OnSurface),
-    onError: Color = Color(ColorPalette.DefaultLight.OnError)
+    primary: Color = ColorPalette.DefaultLight.Primary,
+    primaryVariant: Color = ColorPalette.DefaultLight.PrimaryVariant,
+    secondary: Color = ColorPalette.DefaultLight.Secondary,
+    secondaryVariant: Color = ColorPalette.DefaultLight.SecondaryVariant,
+    background: Color = ColorPalette.DefaultLight.Background,
+    surface: Color = ColorPalette.DefaultLight.Surface,
+    error: Color = ColorPalette.DefaultLight.Error,
+    onPrimary: Color = ColorPalette.DefaultLight.OnPrimary,
+    onSecondary: Color = ColorPalette.DefaultLight.OnSecondary,
+    onBackground: Color = ColorPalette.DefaultLight.OnBackground,
+    onSurface: Color = ColorPalette.DefaultLight.OnSurface,
+    onError: Color = ColorPalette.DefaultLight.OnError,
 ): MaasColorPalette = MaasColorPalette(
     primary = primary,
     primaryVariant = primaryVariant,
@@ -45,22 +45,22 @@ fun MaasTheme.lightColors(
     onBackground = onBackground,
     onSurface = onSurface,
     onError = onError,
-    isLight = true
+    isLight = true,
 )
 
 fun MaasTheme.darkColors(
-    primary: Color = Color(ColorPalette.DefaultDark.Primary),
-    primaryVariant: Color = Color(ColorPalette.DefaultDark.PrimaryVariant),
-    secondary: Color = Color(ColorPalette.DefaultDark.Secondary),
-    secondaryVariant: Color = Color(ColorPalette.DefaultDark.SecondaryVariant),
-    background: Color = Color(ColorPalette.DefaultDark.Background),
-    surface: Color = Color(ColorPalette.DefaultDark.Surface),
-    error: Color = Color(ColorPalette.DefaultDark.Error),
-    onPrimary: Color = Color(ColorPalette.DefaultDark.OnPrimary),
-    onSecondary: Color = Color(ColorPalette.DefaultDark.OnSecondary),
-    onBackground: Color = Color(ColorPalette.DefaultDark.OnBackground),
-    onSurface: Color = Color(ColorPalette.DefaultDark.OnSurface),
-    onError: Color = Color(ColorPalette.DefaultDark.OnError)
+    primary: Color = ColorPalette.DefaultDark.Primary,
+    primaryVariant: Color = ColorPalette.DefaultDark.PrimaryVariant,
+    secondary: Color = ColorPalette.DefaultDark.Secondary,
+    secondaryVariant: Color = ColorPalette.DefaultDark.SecondaryVariant,
+    background: Color = ColorPalette.DefaultDark.Background,
+    surface: Color = ColorPalette.DefaultDark.Surface,
+    error: Color = ColorPalette.DefaultDark.Error,
+    onPrimary: Color = ColorPalette.DefaultDark.OnPrimary,
+    onSecondary: Color = ColorPalette.DefaultDark.OnSecondary,
+    onBackground: Color = ColorPalette.DefaultDark.OnBackground,
+    onSurface: Color = ColorPalette.DefaultDark.OnSurface,
+    onError: Color = ColorPalette.DefaultDark.OnError,
 ): MaasColorPalette = MaasColorPalette(
     primary = primary,
     primaryVariant = primaryVariant,
@@ -74,7 +74,7 @@ fun MaasTheme.darkColors(
     onBackground = onBackground,
     onSurface = onSurface,
     onError = onError,
-    isLight = false
+    isLight = false,
 )
 
 @Stable
@@ -91,7 +91,7 @@ class MaasColorPalette(
     onBackground: Color,
     onSurface: Color,
     onError: Color,
-    isLight: Boolean
+    isLight: Boolean,
 ) {
     var primary by mutableStateOf(primary)
         private set

--- a/android/ui/src/main/java/com/trafi/ui/theme/CornerRadius.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/CornerRadius.kt
@@ -5,17 +5,16 @@ package com.trafi.ui.theme
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.trafi.ui.theme.internal.CornerRadiusScale
 
 object CornerRadius {
-    @Stable val none: Dp = CornerRadiusScale.none.dp
-    @Stable val xxs: Dp = CornerRadiusScale.xxs.dp
-    @Stable val xs: Dp = CornerRadiusScale.xs.dp
-    @Stable val sm: Dp = CornerRadiusScale.sm.dp
-    @Stable val lg: Dp = CornerRadiusScale.lg.dp
-    @Stable val xl: Dp = CornerRadiusScale.xl.dp
-    @Stable val round: Dp = CornerRadiusScale.round.dp
+    @Stable val none: Dp = CornerRadiusScale.none
+    @Stable val xxs: Dp = CornerRadiusScale.xxs
+    @Stable val xs: Dp = CornerRadiusScale.xs
+    @Stable val sm: Dp = CornerRadiusScale.sm
+    @Stable val lg: Dp = CornerRadiusScale.lg
+    @Stable val xl: Dp = CornerRadiusScale.xl
+    @Stable val round: Dp = CornerRadiusScale.round
 }
 
 @Stable
@@ -24,5 +23,5 @@ internal val Dp.isRound: Boolean
 
 @Immutable
 data class MaasCornerRadius(
-    val buttonRadius: Dp = CornerRadiusScale.Default.ButtonRadius.dp
+    val buttonRadius: Dp = CornerRadiusScale.Default.ButtonRadius
 )

--- a/android/ui/src/main/java/com/trafi/ui/theme/CurrentTheme.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/CurrentTheme.kt
@@ -1,9 +1,6 @@
 package com.trafi.ui.theme
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.Dp
 import com.trafi.ui.theme.internal.CurrentColorPalette
 import com.trafi.ui.theme.internal.CurrentCornerRadiusScale
 import com.trafi.ui.theme.internal.CurrentSpacingScale
@@ -12,52 +9,43 @@ import com.trafi.ui.theme.internal.CurrentTypographyScale
 
 @Composable
 internal val currentTheme: CurrentTheme
-    get() {
-        val colors = MaasTheme.colors
-        val typography = MaasTheme.typography
-        val spacing = MaasTheme.spacing
-        val cornerRadius = MaasTheme.cornerRadius
-        return CurrentTheme(
-            colorPalette = with(colors) {
-                CurrentColorPalette(
-                    primary = primary.osColor,
-                    primaryVariant = primaryVariant.osColor,
-                    secondary = secondary.osColor,
-                    secondaryVariant = secondaryVariant.osColor,
-                    background = background.osColor,
-                    surface = surface.osColor,
-                    error = error.osColor,
-                    onPrimary = onPrimary.osColor,
-                    onSecondary = onSecondary.osColor,
-                    onBackground = onBackground.osColor,
-                    onSurface = onSurface.osColor,
-                    onError = onError.osColor,
-                )
-            },
-            typographyScale = with(typography) {
-                CurrentTypographyScale(
-                    headingXXL = headingXXL,
-                    headingXL = headingXL,
-                    headingL = headingL,
-                    headingM = headingM,
-                    textL = textL,
-                    textM = textM,
-                    textS = textS,
-                    label = label,
-                )
-            },
-            spacingScale = with(spacing) {
-                CurrentSpacingScale(
-                    globalMargin = globalMargin.osDimension
-                )
-            },
-            cornerRadiusScale = with(cornerRadius) {
-                CurrentCornerRadiusScale(
-                    buttonRadius = buttonRadius.osDimension
-                )
-            },
-        )
-    }
-
-private val Color.osColor: Long get() = toArgb().toLong()
-private val Dp.osDimension: Float get() = value
+    get() = CurrentTheme(
+        colorPalette = with(MaasTheme.colors) {
+            CurrentColorPalette(
+                primary = primary,
+                primaryVariant = primaryVariant,
+                secondary = secondary,
+                secondaryVariant = secondaryVariant,
+                background = background,
+                surface = surface,
+                error = error,
+                onPrimary = onPrimary,
+                onSecondary = onSecondary,
+                onBackground = onBackground,
+                onSurface = onSurface,
+                onError = onError,
+            )
+        },
+        typographyScale = with(MaasTheme.typography) {
+            CurrentTypographyScale(
+                headingXXL = headingXXL,
+                headingXL = headingXL,
+                headingL = headingL,
+                headingM = headingM,
+                textL = textL,
+                textM = textM,
+                textS = textS,
+                label = label,
+            )
+        },
+        spacingScale = with(MaasTheme.spacing) {
+            CurrentSpacingScale(
+                globalMargin = globalMargin
+            )
+        },
+        cornerRadiusScale = with(MaasTheme.cornerRadius) {
+            CurrentCornerRadiusScale(
+                buttonRadius = buttonRadius
+            )
+        },
+    )

--- a/android/ui/src/main/java/com/trafi/ui/theme/Spacing.kt
+++ b/android/ui/src/main/java/com/trafi/ui/theme/Spacing.kt
@@ -5,22 +5,21 @@ package com.trafi.ui.theme
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.trafi.ui.theme.internal.SpacingScale
 
 object Spacing {
-    @Stable val xxxs: Dp = SpacingScale.xxxs.dp
-    @Stable val xxs: Dp = SpacingScale.xxs.dp
-    @Stable val xs: Dp = SpacingScale.xs.dp
-    @Stable val sm: Dp = SpacingScale.sm.dp
-    @Stable val md: Dp = SpacingScale.md.dp
-    @Stable val lg: Dp = SpacingScale.lg.dp
-    @Stable val xl: Dp = SpacingScale.xl.dp
-    @Stable val xxl: Dp = SpacingScale.xxl.dp
-    @Stable val xxxl: Dp = SpacingScale.xxxl.dp
+    @Stable val xxxs: Dp = SpacingScale.xxxs
+    @Stable val xxs: Dp = SpacingScale.xxs
+    @Stable val xs: Dp = SpacingScale.xs
+    @Stable val sm: Dp = SpacingScale.sm
+    @Stable val md: Dp = SpacingScale.md
+    @Stable val lg: Dp = SpacingScale.lg
+    @Stable val xl: Dp = SpacingScale.xl
+    @Stable val xxl: Dp = SpacingScale.xxl
+    @Stable val xxxl: Dp = SpacingScale.xxxl
 }
 
 @Immutable
 data class MaasSpacing(
-    val globalMargin: Dp = SpacingScale.Default.GlobalMargin.dp
+    val globalMargin: Dp = SpacingScale.Default.GlobalMargin
 )

--- a/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/Color.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/Color.kt
@@ -1,0 +1,3 @@
+package com.trafi.ui.theme.internal
+
+actual typealias Color = androidx.compose.ui.graphics.Color

--- a/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
@@ -1,0 +1,3 @@
+package com.trafi.ui.theme.internal
+
+actual typealias Dp = androidx.compose.ui.unit.Dp

--- a/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
+++ b/common/core/src/androidMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
@@ -1,30 +1,29 @@
 package com.trafi.ui.theme.internal
 
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-actual typealias OsTextStyle = TextStyle
+actual typealias TextStyle = androidx.compose.ui.text.TextStyle
 
-internal actual fun OsTextStyle.copy(
+internal actual fun TextStyle.copy(
     fontStyle: BasicFontStyle?,
     fontWeight: BasicFontWeight?,
     fontSize: Int?,
     lineHeight: Int?,
-): OsTextStyle = copy(
+): TextStyle = copy(
     fontStyle = fontStyle?.os ?: this.fontStyle,
     fontWeight = fontWeight?.os ?: this.fontWeight,
     fontSize = fontSize?.sp ?: this.fontSize,
     lineHeight = lineHeight?.sp ?: this.lineHeight
 )
 
-internal actual fun OsTextStyle(
+internal actual fun TextStyle(
     fontStyle: BasicFontStyle,
     fontWeight: BasicFontWeight,
     fontSize: Int,
     lineHeight: Int,
-): OsTextStyle = TextStyle(
+): TextStyle = TextStyle(
     fontStyle = fontStyle.os,
     fontWeight = fontWeight.os,
     fontSize = fontSize.sp,

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
@@ -3,3 +3,5 @@
 package com.trafi.ui.theme.internal
 
 expect inline class Color(val value: ULong)
+
+internal fun Color(value: Long) = Color(value.toULong())

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING", "EXPERIMENTAL_API_USAGE")
+
+package com.trafi.ui.theme.internal
+
+expect inline class Color(val value: ULong)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Color.kt
@@ -1,6 +1,9 @@
 @file:Suppress("EXPERIMENTAL_FEATURE_WARNING", "EXPERIMENTAL_API_USAGE")
+@file:JvmName("Color")
 
 package com.trafi.ui.theme.internal
+
+import kotlin.jvm.JvmName
 
 expect inline class Color(val value: ULong)
 

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/ColorPalette.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/ColorPalette.kt
@@ -1,46 +1,46 @@
 package com.trafi.ui.theme.internal
 
 object ColorPalette {
-    const val White = 0xffffffff
-    const val Black = 0xff000000
+    val White = Color(0xffffffff)
+    val Black = Color(0xff000000)
 
-    const val Gray100 = 0xfff5f5f5
-    const val Gray200 = 0xffeeeeee
-    const val Gray300 = 0xffe0e0e0
-    const val Gray400 = 0xffbdbdbd
-    const val Gray500 = 0xff9e9e9e
-    const val Gray600 = 0xff757575
-    const val Gray700 = 0xff616161
-    const val Gray800 = 0xff424242
-    const val Gray900 = 0xff212121
+    val Gray100 = Color(0xfff5f5f5)
+    val Gray200 = Color(0xffeeeeee)
+    val Gray300 = Color(0xffe0e0e0)
+    val Gray400 = Color(0xffbdbdbd)
+    val Gray500 = Color(0xff9e9e9e)
+    val Gray600 = Color(0xff757575)
+    val Gray700 = Color(0xff616161)
+    val Gray800 = Color(0xff424242)
+    val Gray900 = Color(0xff212121)
 
     object DefaultLight {
-        const val Primary = 0xffff1499
-        const val PrimaryVariant = 0xffd20077
-        const val Secondary = 0xff73008b
-        const val SecondaryVariant = 0xff59006c
-        const val Background = White
-        const val Surface = White
-        const val Error = 0xfff22e46
-        const val OnPrimary = White
-        const val OnSecondary = Black
-        const val OnBackground = Gray900
-        const val OnSurface = Gray900
-        const val OnError = White
+        val Primary = Color(0xffff1499)
+        val PrimaryVariant = Color(0xffd20077)
+        val Secondary = Color(0xff73008b)
+        val SecondaryVariant = Color(0xff59006c)
+        val Background = White
+        val Surface = White
+        val Error = Color(0xfff22e46)
+        val OnPrimary = White
+        val OnSecondary = Black
+        val OnBackground = Gray900
+        val OnSurface = Gray900
+        val OnError = White
     }
 
     object DefaultDark {
-        const val Primary = 0xffff1499
-        const val PrimaryVariant = 0xffd20077
-        const val Secondary = 0xff73008b
-        const val SecondaryVariant = 0xff59006c
-        const val Background = Black
-        const val Surface = Black
-        const val Error = 0xfff22e46
-        const val OnPrimary = White
-        const val OnSecondary = Black
-        const val OnBackground = White
-        const val OnSurface = White
-        const val OnError = White
+        val Primary = Color(0xffff1499)
+        val PrimaryVariant = Color(0xffd20077)
+        val Secondary = Color(0xff73008b)
+        val SecondaryVariant = Color(0xff59006c)
+        val Background = Black
+        val Surface = Black
+        val Error = Color(0xfff22e46)
+        val OnPrimary = White
+        val OnSecondary = Black
+        val OnBackground = White
+        val OnSurface = White
+        val OnError = White
     }
 }

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CornerRadiusScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CornerRadiusScale.kt
@@ -7,7 +7,7 @@ object CornerRadiusScale {
     const val sm = 8
     const val lg = 12
     const val xl = 20
-    const val round = infinity
+    const val round = maxValue
 
     object Default {
         const val ButtonRadius = round

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CornerRadiusScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CornerRadiusScale.kt
@@ -1,15 +1,15 @@
 package com.trafi.ui.theme.internal
 
 object CornerRadiusScale {
-    const val none = 0
-    const val xxs = 4
-    const val xs = 6
-    const val sm = 8
-    const val lg = 12
-    const val xl = 20
-    const val round = maxValue
+    val none = 0.dp
+    val xxs = 4.dp
+    val xs = 6.dp
+    val sm = 8.dp
+    val lg = 12.dp
+    val xl = 20.dp
+    val round = maxValue.dp
 
     object Default {
-        const val ButtonRadius = round
+        val ButtonRadius = round
     }
 }

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentColorPalette.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentColorPalette.kt
@@ -1,16 +1,16 @@
 package com.trafi.ui.theme.internal
 
 class CurrentColorPalette(
-    val primary: OsColor,
-    val primaryVariant: OsColor,
-    val secondary: OsColor,
-    val secondaryVariant: OsColor,
-    val background: OsColor,
-    val surface: OsColor,
-    val error: OsColor,
-    val onPrimary: OsColor,
-    val onSecondary: OsColor,
-    val onBackground: OsColor,
-    val onSurface: OsColor,
-    val onError: OsColor,
+    val primary: Color,
+    val primaryVariant: Color,
+    val secondary: Color,
+    val secondaryVariant: Color,
+    val background: Color,
+    val surface: Color,
+    val error: Color,
+    val onPrimary: Color,
+    val onSecondary: Color,
+    val onBackground: Color,
+    val onSurface: Color,
+    val onError: Color,
 )

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentCornerRadiusScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentCornerRadiusScale.kt
@@ -1,5 +1,5 @@
 package com.trafi.ui.theme.internal
 
 class CurrentCornerRadiusScale(
-    val buttonRadius: OsDimension,
+    val buttonRadius: Dp,
 )

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentSpacingScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentSpacingScale.kt
@@ -1,5 +1,5 @@
 package com.trafi.ui.theme.internal
 
 class CurrentSpacingScale(
-    val globalMargin: OsDimension,
+    val globalMargin: Dp,
 )

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTypographyScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/CurrentTypographyScale.kt
@@ -1,12 +1,12 @@
 package com.trafi.ui.theme.internal
 
 class CurrentTypographyScale(
-    val headingXXL: OsTextStyle,
-    val headingXL: OsTextStyle,
-    val headingL: OsTextStyle,
-    val headingM: OsTextStyle,
-    val textL: OsTextStyle,
-    val textM: OsTextStyle,
-    val textS: OsTextStyle,
-    val label: OsTextStyle,
+    val headingXXL: TextStyle,
+    val headingXL: TextStyle,
+    val headingL: TextStyle,
+    val headingM: TextStyle,
+    val textL: TextStyle,
+    val textM: TextStyle,
+    val textS: TextStyle,
+    val label: TextStyle,
 )

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+
+package com.trafi.ui.theme.internal
+
+expect inline class Dp(val value: Float)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
@@ -3,3 +3,6 @@
 package com.trafi.ui.theme.internal
 
 expect inline class Dp(val value: Float)
+
+internal val Int.dp get() = Dp(toFloat())
+internal val Float.dp get() = Dp(this)

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
@@ -1,6 +1,9 @@
 @file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+@file:JvmName("Dp")
 
 package com.trafi.ui.theme.internal
+
+import kotlin.jvm.JvmName
 
 expect inline class Dp(val value: Float)
 

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
@@ -1,6 +1,6 @@
 package com.trafi.ui.theme.internal
 
-internal const val infinity = Float.POSITIVE_INFINITY
+internal const val maxValue = Float.MAX_VALUE
 
 internal fun textStyle(builder: TextStyleBuilder.() -> Unit): OsTextStyle =
     TextStyleBuilder().apply(builder).build()

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/Dsl.kt
@@ -2,7 +2,7 @@ package com.trafi.ui.theme.internal
 
 internal const val maxValue = Float.MAX_VALUE
 
-internal fun textStyle(builder: TextStyleBuilder.() -> Unit): OsTextStyle =
+internal fun textStyle(builder: TextStyleBuilder.() -> Unit): TextStyle =
     TextStyleBuilder().apply(builder).build()
 
 internal class TextStyleBuilder(
@@ -11,7 +11,7 @@ internal class TextStyleBuilder(
     var fontSize: Int? = null,
     var lineHeight: Int? = null,
 ) {
-    fun build(): OsTextStyle = OsTextStyle(
+    fun build(): TextStyle = TextStyle(
         fontStyle = fontStyle,
         fontWeight = fontWeight,
         fontSize = requireNotNull(fontSize),

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsColor.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsColor.kt
@@ -1,3 +1,0 @@
-package com.trafi.ui.theme.internal
-
-typealias OsColor = Long

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsDimension.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/OsDimension.kt
@@ -1,3 +1,0 @@
-package com.trafi.ui.theme.internal
-
-typealias OsDimension = Float

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/SpacingScale.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/SpacingScale.kt
@@ -1,17 +1,17 @@
 package com.trafi.ui.theme.internal
 
 object SpacingScale {
-    const val xxxs = 2
-    const val xxs = 4
-    const val xs = 8
-    const val sm = 12
-    const val md = 16
-    const val lg = 20
-    const val xl = 24
-    const val xxl = 32
-    const val xxxl = 48
+    val xxxs = 2.dp
+    val xxs = 4.dp
+    val xs = 8.dp
+    val sm = 12.dp
+    val md = 16.dp
+    val lg = 20.dp
+    val xl = 24.dp
+    val xxl = 32.dp
+    val xxxl = 48.dp
 
     object Default {
-        const val GlobalMargin = xl
+        val GlobalMargin = xl
     }
 }

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
@@ -1,17 +1,17 @@
 package com.trafi.ui.theme.internal
 
-expect class OsTextStyle
+expect class TextStyle
 
-internal expect fun OsTextStyle.copy(
+internal expect fun TextStyle.copy(
     fontStyle: BasicFontStyle? = null,
     fontWeight: BasicFontWeight? = null,
     fontSize: Int? = null,
     lineHeight: Int? = null,
-): OsTextStyle
+): TextStyle
 
-internal expect fun OsTextStyle(
+internal expect fun TextStyle(
     fontStyle: BasicFontStyle,
     fontWeight: BasicFontWeight,
     fontSize: Int,
     lineHeight: Int,
-): OsTextStyle
+): TextStyle

--- a/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/Color.kt
+++ b/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/Color.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING", "EXPERIMENTAL_API_USAGE")
+
+package com.trafi.ui.theme.internal
+
+actual inline class Color(val value: ULong)

--- a/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
+++ b/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/Dp.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+
+package com.trafi.ui.theme.internal
+
+actual inline class Dp(val value: Float)

--- a/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
+++ b/common/core/src/iosMain/kotlin/com/trafi/ui/theme/internal/TextStyle.kt
@@ -2,14 +2,14 @@ package com.trafi.ui.theme.internal
 
 import platform.UIKit.*
 
-actual typealias OsTextStyle = UIFont
+actual typealias TextStyle = UIFont
 
-internal actual fun OsTextStyle.copy(
+internal actual fun TextStyle.copy(
     fontStyle: BasicFontStyle?,
     fontWeight: BasicFontWeight?,
     fontSize: Int?,
     lineHeight: Int?,
-): OsTextStyle {
+): TextStyle {
     var descriptor = this.fontDescriptor
     if (fontStyle?.os != null) {
         descriptor = descriptor.fontDescriptorWithSymbolicTraits(fontStyle.os!!) ?: descriptor
@@ -25,12 +25,12 @@ internal actual fun OsTextStyle.copy(
     return UIFont.fontWithDescriptor(descriptor,fontSize?.os ?: this.pointSize)
 }
 
-internal actual fun OsTextStyle(
+internal actual fun TextStyle(
     fontStyle: BasicFontStyle,
     fontWeight: BasicFontWeight,
     fontSize: Int,
     lineHeight: Int,
-): OsTextStyle = UIFont.systemFontOfSize(fontSize.os).copy(fontStyle, fontWeight, lineHeight)
+): TextStyle = UIFont.systemFontOfSize(fontSize.os).copy(fontStyle, fontWeight, lineHeight)
 
 private val BasicFontStyle.os get() = when (this) {
     BasicFontStyle.Normal -> null

--- a/ios/Sources/MaaSTheme/Colors.swift
+++ b/ios/Sources/MaaSTheme/Colors.swift
@@ -3,53 +3,41 @@ import UIKit
 import MaasCore
 
 private enum ColorKeys {
-
-    static let L = ColorPalette.DefaultLight()
-    static let D = ColorPalette.DefaultDark()
-
-    static func dynamic(light: Int64, dark: Int64) -> UIColor {
-        UIColor { traits in
-            traits.userInterfaceStyle == .dark ?
-                dark.uiColor :
-                light.uiColor
-        }
-    }
-
     struct Primary: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.Primary, dark: D.Primary) }
+        static var defaultValue: UIColor { .adaptive(light: \.Primary, dark: \.Primary) }
     }
     struct OnPrimary: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.OnPrimary, dark: D.OnPrimary) }
+        static var defaultValue: UIColor { .adaptive(light: \.OnPrimary, dark: \.OnPrimary) }
     }
     struct PrimaryVariant: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.PrimaryVariant, dark: D.PrimaryVariant) }
+        static var defaultValue: UIColor { .adaptive(light: \.PrimaryVariant, dark: \.PrimaryVariant) }
     }
     struct Secondary: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.Secondary, dark: D.Secondary) }
+        static var defaultValue: UIColor { .adaptive(light: \.Secondary, dark: \.Secondary) }
     }
     struct OnSecondary: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.OnSecondary, dark: D.OnSecondary) }
+        static var defaultValue: UIColor { .adaptive(light: \.OnSecondary, dark: \.OnSecondary) }
     }
     struct SecondaryVariant: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.SecondaryVariant, dark: D.SecondaryVariant) }
+        static var defaultValue: UIColor { .adaptive(light: \.SecondaryVariant, dark: \.SecondaryVariant) }
     }
     struct Background: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.Background, dark: D.Background) }
+        static var defaultValue: UIColor { .adaptive(light: \.Background, dark: \.Background) }
     }
     struct OnBackground: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.OnBackground, dark: D.OnBackground) }
+        static var defaultValue: UIColor { .adaptive(light: \.OnBackground, dark: \.OnBackground) }
     }
     struct Surface: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.Surface, dark: D.Surface) }
+        static var defaultValue: UIColor { .adaptive(light: \.Surface, dark: \.Surface) }
     }
     struct OnSurface: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.OnSurface, dark: D.OnSurface) }
+        static var defaultValue: UIColor { .adaptive(light: \.OnSurface, dark: \.OnSurface) }
     }
     struct Error: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.Error, dark: D.Error) }
+        static var defaultValue: UIColor { .adaptive(light: \.Error, dark: \.Error) }
     }
     struct OnError: EnvironmentKey {
-        static var defaultValue: UIColor { dynamic(light: L.OnError, dark: D.OnError) }
+        static var defaultValue: UIColor { .adaptive(light: \.OnError, dark: \.OnError) }
     }
 }
 
@@ -117,12 +105,21 @@ public extension EnvironmentValues {
     }
 }
 
-public extension Int64 {
-    var color: Color {
-        return Color(uiColor)
-    }
+// MARK: - From Kotlin
 
-    var uiColor: UIColor {
+private extension UIColor {
+    static func adaptive(light: KeyPath<ColorPalette.DefaultLight, UInt64>,
+                         dark: KeyPath<ColorPalette.DefaultDark, UInt64>) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark ?
+                ColorPalette.DefaultDark()[keyPath: dark].color :
+                ColorPalette.DefaultLight()[keyPath: light].color
+        }
+    }
+}
+
+extension UInt64 {
+    var color: UIColor {
         let a = CGFloat((self & 0xff000000) >> 24) / 255
         let r = CGFloat((self & 0x00ff0000) >> 16) / 255
         let g = CGFloat((self & 0x0000ff00) >> 8) / 255
@@ -132,8 +129,10 @@ public extension Int64 {
     }
 }
 
+// MARK: - To Kotlin
+
 extension UIColor {
-    func i64(_ colorScheme: ColorScheme) -> Int64 {
+    func ui64(_ colorScheme: ColorScheme) -> UInt64 {
 
         var r: CGFloat = 0
         var g: CGFloat = 0
@@ -143,7 +142,7 @@ extension UIColor {
         let color = resolvedColor(with: UITraitCollection(userInterfaceStyle: colorScheme.interfaceStyle))
         color.getRed(&r, green: &g, blue: &b, alpha: &a)
 
-        return (Int64)(a*255)<<24 | (Int64)(r*255)<<16 | (Int64)(g*255)<<8 | (Int64)(b*255)<<0
+        return (UInt64)(a*255)<<24 | (UInt64)(r*255)<<16 | (UInt64)(g*255)<<8 | (UInt64)(b*255)<<0
     }
 }
 

--- a/ios/Sources/MaaSTheme/CornerRadius.swift
+++ b/ios/Sources/MaaSTheme/CornerRadius.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import UIKit
 import MaasCore
 
-struct CornerRadiusButton: EnvironmentKey {
-    static var defaultValue: CGFloat { CornerRadiusScale.Default().ButtonRadius.cgFloat }
+private struct CornerRadiusButton: EnvironmentKey {
+    static var defaultValue: CGFloat { CGFloat(CornerRadiusScale.Default().ButtonRadius) }
 }
 public extension EnvironmentValues {
     var cornerRadiusButton: CGFloat {
@@ -24,16 +24,4 @@ public struct CornerRadius {
     public static var lg: CornerRadius { .init(value: CGFloat(CornerRadiusScale().lg)) }
     public static var xl: CornerRadius { .init(value: CGFloat(CornerRadiusScale().xl)) }
     public static var round: CornerRadius { .init(value: CGFloat(CornerRadiusScale().round)) }
-}
-
-public extension Float {
-    public var cgFloat: CGFloat {
-        self == Float.infinity ? .greatestFiniteMagnitude : CGFloat(self)
-    }
-}
-
-public extension CGFloat {
-    public var float: Float {
-        self == CGFloat.greatestFiniteMagnitude ? Float.infinity : Float(self)
-    }
 }

--- a/ios/Sources/MaaSTheme/Kotlin.swift
+++ b/ios/Sources/MaaSTheme/Kotlin.swift
@@ -1,0 +1,25 @@
+import UIKit
+import SwiftUI
+
+@dynamicMemberLookup
+public struct Kotlin<T> {
+
+    let value: T
+    public init(_ value: T) { self.value = value }
+
+    public subscript(dynamicMember keyPath: KeyPath<T, UIFont>) -> Font {
+        Font(value[keyPath: keyPath])
+    }
+
+    public subscript(dynamicMember keyPath: KeyPath<T, UInt64>) -> Color {
+        Color(value[keyPath: keyPath].color)
+    }
+
+    public subscript(dynamicMember keyPath: KeyPath<T, Float>) -> CGFloat {
+        CGFloat(value[keyPath: keyPath])
+    }
+
+    public subscript(dynamicMember keyPath: KeyPath<T, Int32>) -> CGFloat {
+        CGFloat(value[keyPath: keyPath])
+    }
+}

--- a/ios/Sources/MaaSTheme/Spacing.swift
+++ b/ios/Sources/MaaSTheme/Spacing.swift
@@ -1,21 +1,32 @@
-import Foundation
+import UIKit
+import SwiftUI
 import MaasCore
+
+private struct SpacingGlobalMargin: EnvironmentKey {
+    static var defaultValue: CGFloat { CGFloat(SpacingScale.Default().GlobalMargin) }
+}
+public extension EnvironmentValues {
+    var spacingGlobalMargin: CGFloat {
+        get { self[SpacingGlobalMargin.self] }
+        set { self[SpacingGlobalMargin.self] = newValue }
+    }
+}
 
 public struct Spacing {
 
-    public let value: Double
+    public let value: CGFloat
 
-    public static var xxxs: Spacing { .init(value: Double(SpacingScale().xxxs)) }
-    public static var xxs: Spacing { .init(value: Double(SpacingScale().xxs)) }
-    public static var xs: Spacing { .init(value: Double(SpacingScale().xs)) }
-    public static var sm: Spacing { .init(value: Double(SpacingScale().sm)) }
-    public static var md: Spacing { .init(value: Double(SpacingScale().md)) }
-    public static var lg: Spacing { .init(value: Double(SpacingScale().lg)) }
-    public static var xl: Spacing { .init(value: Double(SpacingScale().xl)) }
-    public static var xxl: Spacing { .init(value: Double(SpacingScale().xxl)) }
-    public static var xxxl: Spacing { .init(value: Double(SpacingScale().xxxl)) }
+    public static var xxxs: Spacing { .init(value: CGFloat(SpacingScale().xxxs)) }
+    public static var xxs: Spacing { .init(value: CGFloat(SpacingScale().xxs)) }
+    public static var xs: Spacing { .init(value: CGFloat(SpacingScale().xs)) }
+    public static var sm: Spacing { .init(value: CGFloat(SpacingScale().sm)) }
+    public static var md: Spacing { .init(value: CGFloat(SpacingScale().md)) }
+    public static var lg: Spacing { .init(value: CGFloat(SpacingScale().lg)) }
+    public static var xl: Spacing { .init(value: CGFloat(SpacingScale().xl)) }
+    public static var xxl: Spacing { .init(value: CGFloat(SpacingScale().xxl)) }
+    public static var xxxl: Spacing { .init(value: CGFloat(SpacingScale().xxxl)) }
 
     public static var `default`: Spacing {
-        .init(value: Double(SpacingScale.Default().GlobalMargin))
+        .init(value: CGFloat(SpacingScale.Default().GlobalMargin))
     }
 }

--- a/ios/Sources/MaaSTheme/Theme.swift
+++ b/ios/Sources/MaaSTheme/Theme.swift
@@ -8,18 +8,18 @@ public extension EnvironmentValues {
         get {
             CurrentTheme(
                 colorPalette: CurrentColorPalette(
-                    primary: uiColorPrimary.i64(colorScheme),
-                    primaryVariant: uiColorPrimaryVariant.i64(colorScheme),
-                    secondary: uiColorSecondary.i64(colorScheme),
-                    secondaryVariant: uiColorSecondaryVariant.i64(colorScheme),
-                    background: uiColorBackground.i64(colorScheme),
-                    surface: uiColorSurface.i64(colorScheme),
-                    error: uiColorError.i64(colorScheme),
-                    onPrimary: uiColorOnPrimary.i64(colorScheme),
-                    onSecondary: uiColorOnSecondary.i64(colorScheme),
-                    onBackground: uiColorOnBackground.i64(colorScheme),
-                    onSurface: uiColorOnSurface.i64(colorScheme),
-                    onError: uiColorOnError.i64(colorScheme)),
+                    primary: uiColorPrimary.ui64(colorScheme),
+                    primaryVariant: uiColorPrimaryVariant.ui64(colorScheme),
+                    secondary: uiColorSecondary.ui64(colorScheme),
+                    secondaryVariant: uiColorSecondaryVariant.ui64(colorScheme),
+                    background: uiColorBackground.ui64(colorScheme),
+                    surface: uiColorSurface.ui64(colorScheme),
+                    error: uiColorError.ui64(colorScheme),
+                    onPrimary: uiColorOnPrimary.ui64(colorScheme),
+                    onSecondary: uiColorOnSecondary.ui64(colorScheme),
+                    onBackground: uiColorOnBackground.ui64(colorScheme),
+                    onSurface: uiColorOnSurface.ui64(colorScheme),
+                    onError: uiColorOnError.ui64(colorScheme)),
                 typographyScale: CurrentTypographyScale(
                     headingXXL: uiFontHeadingXXL,
                     headingXL: uiFontHeadingXL,
@@ -31,10 +31,10 @@ public extension EnvironmentValues {
                     label: uiFontLabel
                 ),
                 spacingScale: CurrentSpacingScale(
-                    globalMargin: Float(SpacingScale.Default().GlobalMargin)
+                    globalMargin: Float(spacingGlobalMargin)
                 ),
                 cornerRadiusScale: CurrentCornerRadiusScale(
-                    buttonRadius: cornerRadiusButton.float)
+                    buttonRadius: Float(cornerRadiusButton))
             )
         }
     }


### PR DESCRIPTION
To share theme-aware UI component values across iOS and Android, we can move them to Kotlin/Native. The initial implementation in #25 moved primitive constants to K/N, but required mapping between primitives and Compose/SwiftUI-native types. Since the mapping had only to be done once, this was not an issue. It becomes an issue when we declare constants for specific UI components (see e.g. #34) as the mapping then has to be done inside of each component, on both iOS & Android.

The goal is to make all theme types - `TextStyle`, `Color` & `Dp` - interop as seamlessly as possible with SwiftUI and Jetpack Compose types even when shared via Kotlin Multiplatform, avoiding mapping where possible. Seamless `TextStyle` was added in #37. This PR adds seamless usage of `Color` and `Dp`.

There are two challenges with `Color` and `Dp` -
1. Compose `TextStyle` is a simple (`data`) `class`, which allows us to use `expect class TextStyle` and map to any Obj-C class (e.g. `UIFont`). Compose `Color` and `Dp`, on the other hand, are `inline class`es, which forces us to use `expect inline class` for seamless interop between K/N & Compose. We cannot `actual typealias` `inline class`es to any Obj-C class.
2. K/N has interop with Obj-C only, not with Swift. SwiftUI types - `Font`, `Color` and `CGFloat` - are Swift types, which means we cannot avoid additional mapping on the Swift side regardless.

As a result, we choose to achieve seamless interop between Kotlin/Android & Kotlin/Native, where it is possible, and present a solution for painless mapping in Swift.

#### Android
Using expect / actual, all three types map directly to Jetpack Compose types by the same name using `actual typealias`. This means no type mapping is required between the Android and Kotlin/Native bridge.

#### iOS
All three types are seamlessly mapped through a `@dynamicMemberLookup struct Kotlin<T>`. For example, let's look at #34 Kotlin constants for button and their types when accessing from Swift:
```kotlin
class ButtonConstants(theme: CurrentTheme) {
     val defaultColor = theme.colorPalette.primary                       // UInt64
     val defaultContentColor = theme.colorPalette.onPrimary              // UInt64
     val textStyle = theme.typographyScale.textL.copy(fontWeight = Bold) // UIFont
     val cornerRadius = theme.cornerRadiusScale.buttonRadius             // Float
 }
```
Using a `Kotlin` wrapper perfectly handles the mapping to types preferred by SwiftUI using key paths:
```swift
var constants: Kotlin<ButtonConstants> { Kotlin(ButtonConstants(theme: currentTheme)) }

constants.defaultColor        // Color
constants.defaultContentColor // Color
constants.textStyle           // Font
constants.cornerRadius        // CGFloat
```