### PR TITLE
Reduce image comparison precision to 0.99

### DIFF
--- a/ios/Tests/MaasTests/SnapSpec.swift
+++ b/ios/Tests/MaasTests/SnapSpec.swift
@@ -12,7 +12,7 @@ class SnapSpec<S>: QuickSpec where S: PreviewProvider, S: Snapped {
             it("Preview") {
                 XCTAssertNil(
                     verifySnapshot(
-                        matching: S.posterPreview(detailed: true), as: .image(),
+                        matching: S.posterPreview(detailed: true), as: .image(precision: 0.99),
                         named: "\(Int(UIScreen.main.scale))x",
                         testName: S.name
                     )


### PR DESCRIPTION
Make image comparison precision 0.99 to avoid test failures because of subpixel misalignments.

Why: https://trafi.slack.com/archives/C01FH9JSHHB/p1607940940101600