### PR TITLE
Increased snapshot verification accuracy

### DIFF
--- a/ios/Tests/MaasTests/Components.swift
+++ b/ios/Tests/MaasTests/Components.swift
@@ -3,8 +3,8 @@ import Quick
 
 final class Components: QuickSpec {
     override func spec() {
-        snapshot(Badge_Previews.self)
-        snapshot(Button_Previews.self)
+        snapshot(Badge_Previews.self, precision: 0.999)
+        snapshot(Button_Previews.self, precision: 0.995)
         snapshot(Cell_Previews.self)
     }
 }

--- a/ios/Tests/MaasTests/SnapSpec.swift
+++ b/ios/Tests/MaasTests/SnapSpec.swift
@@ -9,13 +9,14 @@ extension QuickSpec {
     func snapshot<S>(
         _: S.Type,
         file: StaticString = #file,
-        line: UInt = #line
+        line: UInt = #line,
+        precision: Float = 1
     ) where S: PreviewProvider, S: Snapped {
 //        isRecording = true
         it(S.name) {
             XCTAssertNil(
                 verifySnapshot(
-                    matching: S.posterPreview(detailed: true), as: .image(precision: 0.995),
+                    matching: S.posterPreview(detailed: true), as: .image(precision: precision),
                     named: "\(Int(UIScreen.main.scale))x",
                     file: file,
                     testName: S.name,

--- a/ios/Tests/MaasTests/SnapSpec.swift
+++ b/ios/Tests/MaasTests/SnapSpec.swift
@@ -15,7 +15,7 @@ extension QuickSpec {
         it(S.name) {
             XCTAssertNil(
                 verifySnapshot(
-                    matching: S.posterPreview(detailed: true), as: .image(precision: 0.99),
+                    matching: S.posterPreview(detailed: true), as: .image(precision: 0.995),
                     named: "\(Int(UIScreen.main.scale))x",
                     file: file,
                     testName: S.name,


### PR DESCRIPTION
Discovered that Badge test still passes if I change text from 12 to 1ą or even 11ą.
It only fails if I change it to 111ą.

Played a bit with snapshot accuracy and from 0.996 and up the Button test starts to fail because of minor text shifts in multiple previews. With 0.995 Button test starts to pass and Badge test fails if text is changed to 11ą (still passes if changed to 1ą).

So keeping the 0.995 setting and this means tests may miss a change of one character.