### PR TITLE
Workflow to run embedmd

### DIFF
--- a/.github/workflows/embedmd.yml
+++ b/.github/workflows/embedmd.yml
@@ -1,0 +1,38 @@
+name: embedmd
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  embed:
+    name: embedmd
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PAT }}
+        ref: ${{ github.head_ref }}
+
+    - name: Get embedmd executable
+      run: go get github.com/campoy/embedmd
+
+    - name: Run embedmd
+      run: |
+        shopt -s globstar
+        embedmd -w **/*.md
+
+    - name: Git Auto Commit
+      uses: stefanzweifel/git-auto-commit-action@v4.8.0
+      with:
+        commit_message: Update code embedded in .md files

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/component/internal/Button.md
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/component/internal/Button.md
@@ -16,15 +16,8 @@
 
 ## API
 [ButtonConstants.kt](ButtonConstants.kt)
-```kotlin
-val defaultBackgroundColor = theme.colorPalette.primary
-val defaultContentColor = theme.colorPalette.onPrimary
-val disabledBackgroundColor = theme.colorPalette.primary.alpha(0.12f)
-val disabledContentColor = theme.colorPalette.onPrimary
-val textStyle = theme.typographyScale.textL.copy(fontWeight = Bold)
-val minHeight = 48.dp
-val cornerRadius = theme.cornerRadiusScale.buttonRadius
-val defaultTruncate = true
-```
+
+[embedmd]:# (ButtonConstants.kt kotlin /class / $)
+
 ## Preview from automated tests
 <img src="../../../../../../../../../../ios/Tests/MaasTests/__Snapshots__/Components/Button.2x.png" width="100%">

--- a/common/core/src/commonMain/kotlin/com/trafi/ui/component/internal/Button.md
+++ b/common/core/src/commonMain/kotlin/com/trafi/ui/component/internal/Button.md
@@ -18,6 +18,18 @@
 [ButtonConstants.kt](ButtonConstants.kt)
 
 [embedmd]:# (ButtonConstants.kt kotlin /class / $)
+```kotlin
+class ButtonConstants(theme: CurrentTheme) {
+    val defaultBackgroundColor = theme.colorPalette.primary
+    val defaultContentColor = theme.colorPalette.onPrimary
+    val disabledBackgroundColor = theme.colorPalette.primary.alpha(0.12f)
+    val disabledContentColor = theme.colorPalette.onPrimary
+    val textStyle = theme.typographyScale.textL.copy(fontWeight = Bold)
+    val minHeight = 48.dp
+    val cornerRadius = theme.cornerRadiusScale.buttonRadius
+    val defaultTruncate = true
+}
+```
 
 ## Preview from automated tests
 <img src="../../../../../../../../../../ios/Tests/MaasTests/__Snapshots__/Components/Button.2x.png" width="100%">


### PR DESCRIPTION
Uses [embedmd](https://github.com/campoy/embedmd) to allow us to embed code into Markdown files.

To embed Kotlin code, just add the macro `[embedmd]:# (relative_path_to_filename.kt kotlin)` in the place you want it embedded. The GitHub action will automatically insert it into the file in a separate commit, **and keep the snippet up-to-date when the code file changes in the future**.

For more details on the macro and available options for inserting only part of the file using regex, see the [embedmd documentation](https://github.com/campoy/embedmd#embedmd).

For example, here I wanted to avoid embedding all the Kotlin import statements. Writing
```kotlin
[embedmd]:# (ButtonConstants.kt kotlin /class / $)
```
embeds only the code from the line containing "class " until the end of the file.