### PR TITLE
Workflow to record Android test screenshots

### DIFF
--- a/.github/workflows/record_android_tests.yml
+++ b/.github/workflows/record_android_tests.yml
@@ -1,0 +1,41 @@
+name: Record Android screenshot tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Choose branch to commit updated screenshots on'     
+        required: true
+
+jobs:
+  record:
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          ref: ${{ github.event.inputs.branch }}
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      -  name: Record screenshots on Android emulator
+         uses: ReactiveCircus/android-emulator-runner@v2.14.2
+         with:
+           api-level: 28
+           target: default
+           arch: x86
+           profile: Nexus 6
+           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+           disable-animations: true
+           script: ./gradlew executeScreenshotTests -Precord
+           working-directory: ./android
+ 
+      - name: Git Auto Commit
+        uses: stefanzweifel/git-auto-commit-action@v4.8.0
+        with:
+          commit_message: Update Android test screenshots
+          file_pattern: '*.png'


### PR DESCRIPTION
Creating new component screenshots, or updating existing ones, requires an emulator that is strictly identical to and run like the one specified in our GitHub workflows:

1. create AVD (Android Virtual Device) using Nexus 6 API 28 x86 profile
1. run `emulator @Nexus_6_API_28 -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim`
1. run `./gradlew executeScreenshotTests -Precord`
1. commit changes

To avoid requiring all contributors to go through these steps, the alternative is to manually run this workflow on a specified branch, which will record new / updated screenshots and automatically commit them to the same branch.

cc @tomasmarciulionis 