### PR TITLE
Tweak Gradle properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,3 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 # We're aware that MP is an alpha feature
 kotlin.mpp.stability.nowarn=true
+# Enable the commonizer
+# https://kotlinlang.org/docs/reference/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -3,3 +3,5 @@ xcodeproj=../ios
 android.useAndroidX=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+# We're aware that MP is an alpha feature
+kotlin.mpp.stability.nowarn=true

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-xcodeproj=./iosApp
+xcodeproj=../ios
 android.useAndroidX=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false


### PR DESCRIPTION
- [enable the commonizer](https://kotlinlang.org/docs/reference/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure) when working from the Android project
- specify the correct Xcode project path for the KMM plugin
- disable Kotlin multiplatform stability warnings