### PR TITLE
MaasCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 // MARK: - Setup
 
-private let environment: Environment = .development
+private let environment: Environment = .production
 
 let package = Package(
     name: "Maas",

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -88,7 +88,7 @@ android {
 
 apply(from = "../../android/scripts/maven-meta.gradle")
 
-val xcframeworkPath = "build/bin/xcframework/MaasCore.xcframework"
+val xcframeworkPath = "../../ios/MaasCore/Sources/MaasCore/Core.xcframework"
 
 val cleanXcframework by tasks.creating(Exec::class) {
 

--- a/docs/Package.swift
+++ b/docs/Package.swift
@@ -1,0 +1,1 @@
+import PackageDescription


### PR DESCRIPTION
Now we can rebuild a `MaasCore.xcframework` with **cmd+b** and we have a cached **MaasCore** it take a few seconds only 🎊 .

Next steps - try to use a AppleScript to have a progress bar or more details about MaasCore construction.

Just need to edit **Maas** scheme **Build/Pre-Actions** run script with this.
```
cd ~/(path to source)/common
./gradlew xcframeworkSimulator
```

No `.executable(...)` used.