### PR TITLE
Rename MaasCore in to CoreBinary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.build
 /Packages
 /*.xcodeproj
+*.xcframework
 xcuserdata/
 .swiftpm
 .idea

--- a/Package.swift
+++ b/Package.swift
@@ -74,9 +74,6 @@ private extension Environment {
             ]
         case .production:
             return [
-                .library(
-                    name: "MaasCore",
-                    targets: ["MaasCore"]),
                .library(
                    name: "MaasRouteSearch",
                    targets: ["MaasRouteSearch"]),
@@ -106,7 +103,7 @@ private extension Environment {
                     path: "ios/MaasCore/Sources/MaasComponents"), 
                 .target(
                     name: "MaasRouteSearch",
-                    dependencies: ["MaasCore", "MaasTheme", "MaasComponents", "Swappable"],
+                    dependencies: ["CoreBinary", "MaasTheme", "MaasComponents", "Swappable"],
                     path: "ios/MaasRouteSearch/Sources",
                     exclude: ["Package.resolved"]),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -93,9 +93,9 @@ private extension Environment {
         case .production:
             return [
                 .binaryTarget(
-                    name: "MaasCore",
-                    url: "https://github.com/trafi/maas-components/releases/download/0.1.0-dev06/MaasCore.xcframework.zip",
-                    checksum: "d22ef85f0be67f6bf54267d4e1924fedc94ad54377281db250d2465e8e1b8448"),
+                    name: "CoreBinary",
+                    url: "https://github.com/trafi/maas-components/releases/download/0.1.0-dev07/CoreBinary.xcframework.zip",
+                    checksum: "50308f39f322be329f65b12f24340d7de22094973dac9159a1c753d1a069e138"),
                 .target(
                     name: "MaasTheme", 
                     dependencies: ["Swappable"],

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
     ios {
         binaries {
             framework {
-                baseName = "MaasCore"
+                baseName = "CoreBinary"
             }
         }
     }
@@ -94,7 +94,7 @@ ktlint {
     }
 }
 
-val xcframeworkPath = "../../ios/MaasCore/Sources/MaasCore/Core.xcframework"
+val xcframeworkPath = "../../ios/MaasCore/Sources/MaasCore/CoreBinary.xcframework"
 
 val cleanXcframework by tasks.registering(Exec::class) {
 

--- a/ios/MaasCore/Package.swift
+++ b/ios/MaasCore/Package.swift
@@ -23,15 +23,11 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
          .binaryTarget(
-             name: "Core",
-             path: "Sources/MaasCore/Core.xcframework"),
-        //.binaryTarget(
-        //    name: "Core",
-        //    url: "https://github.com/trafi/maas-components/releases/download/0.1.0-dev06/MaasCore.xcframework.zip",
-        //    checksum: "d22ef85f0be67f6bf54267d4e1924fedc94ad54377281db250d2465e8e1b8448"),
+             name: "CoreBinary",
+             path: "Sources/MaasCore/CoreBinary.xcframework"),
         .target(
             name: "MaasCore",
-            dependencies: ["Core", "MaasTheme", "MaasComponents"],
+            dependencies: ["CoreBinary", "MaasTheme", "MaasComponents"],
             path: "Sources/MaasCore"),
         .target(
             name: "MaasTheme",


### PR DESCRIPTION
We need to rename out current `MaasCore.xcframework` in to `CoreBinary.xcframework` so that we could use this in our `MaasCore` 📦 