### PR TITLE
Parse API response error body

### DIFF
--- a/android/app/src/main/java/com/trafi/example/DemoApp.kt
+++ b/android/app/src/main/java/com/trafi/example/DemoApp.kt
@@ -5,6 +5,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigate
 import androidx.navigation.compose.rememberNavController
+import com.trafi.core.ApiConfiguration
 import com.trafi.example.ui.DemoMaasTheme
 import com.trafi.routes.ui.RoutesScreen
 
@@ -27,8 +28,7 @@ private fun AppContent() {
         }
         composable("routes") {
             RoutesScreen(
-                baseUrl = BuildConfig.API_BASE_URL,
-                apiKey = BuildConfig.API_KEY,
+                apiConfig = apiConfig,
                 regionId = BuildConfig.REGION_ID,
                 onRouteClick = {},
                 onBackClick = { navController.popBackStack() },
@@ -36,3 +36,9 @@ private fun AppContent() {
         }
     }
 }
+
+private val apiConfig: ApiConfiguration =
+    ApiConfiguration(
+        baseUrl = BuildConfig.API_BASE_URL,
+        apiKey = BuildConfig.API_KEY,
+    )

--- a/android/routes-ui-android/src/main/java/com/trafi/routes/ui/RoutesScreen.kt
+++ b/android/routes-ui-android/src/main/java/com/trafi/routes/ui/RoutesScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.viewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.trafi.core.ApiConfiguration
 import com.trafi.core.model.AutoCompleteLocation
 import com.trafi.core.model.Location
 import com.trafi.core.model.Route
@@ -42,8 +43,7 @@ import com.trafi.ui.theme.Spacing
 
 @Composable
 public fun RoutesScreen(
-    baseUrl: String,
-    apiKey: String,
+    apiConfig: ApiConfiguration,
     regionId: String,
     onBackClick: () -> Unit,
     onRouteClick: (Route) -> Unit,
@@ -51,7 +51,7 @@ public fun RoutesScreen(
     initialStart: Location? = null,
     initialEnd: Location? = null,
 ) {
-    val factory = ViewModelFactory(baseUrl, apiKey, regionId)
+    val factory = ViewModelFactory(apiConfig, regionId)
     val routesViewModel: RoutesViewModel = viewModel(factory = factory)
     val locationViewModel: LocationSearchViewModel = viewModel(factory = factory)
 
@@ -238,11 +238,11 @@ private fun RouteSearchTabsListPreview() {
     )
 }
 
-private class ViewModelFactory(baseUrl: String, apiKey: String, regionId: String) :
+private class ViewModelFactory(apiConfig: ApiConfiguration, regionId: String) :
     ViewModelProvider.Factory {
 
-    private val locationsApi: LocationsApi by lazy { LocationsApi(baseUrl, apiKey, regionId) }
-    private val routesApi: RoutesApi by lazy { RoutesApi(baseUrl, apiKey) }
+    private val locationsApi: LocationsApi by lazy { LocationsApi(apiConfig, regionId) }
+    private val routesApi: RoutesApi by lazy { RoutesApi(apiConfig) }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
+                implementation("io.ktor:ktor-client-mock:${Versions.ktor}")
             }
         }
         val androidMain by getting {

--- a/common/core/src/androidTest/kotlin/com/trafi/test/RunBlocking.kt
+++ b/common/core/src/androidTest/kotlin/com/trafi/test/RunBlocking.kt
@@ -1,0 +1,6 @@
+package com.trafi.test
+
+import kotlinx.coroutines.CoroutineScope
+
+actual fun <T> runBlocking(block: suspend CoroutineScope.() -> T): T =
+    kotlinx.coroutines.runBlocking(block = block)

--- a/common/core/src/commonMain/kotlin/com/trafi/core/ApiResult.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/core/ApiResult.kt
@@ -1,4 +1,14 @@
+@file:Suppress("unused")
+
 package com.trafi.core
+
+import com.trafi.core.model.Error
+import io.ktor.client.features.ResponseException
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.readRemaining
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 /**
  * A discriminated union that encapsulates a successful result with a value of type [T]
@@ -8,6 +18,51 @@ package com.trafi.core
  * [interop with Objective-C](https://kotlinlang.org/docs/reference/native/objc_interop.html#generics).
  */
 sealed class ApiResult<out T : Any> {
-    class Success<T : Any>(val value: T) : ApiResult<T>()
-    class Failure<T : Any>(val exception: Throwable) : ApiResult<T>()
+    class Success<T : Any> internal constructor(val value: T) : ApiResult<T>()
+
+    sealed class Failure<T : Any>(val throwable: Throwable) : ApiResult<T>() {
+        class Unauthorized<T : Any> internal constructor(
+            throwable: Throwable,
+            val httpStatusCode: Int,
+            val error: com.trafi.core.model.Error? = null,
+        ) : Failure<T>(throwable)
+
+        class Error<T : Any> internal constructor(
+            throwable: Throwable,
+            val httpStatusCode: Int,
+            val error: com.trafi.core.model.Error? = null,
+        ) : Failure<T>(throwable)
+
+        class Generic<T : Any> internal constructor(
+            throwable: Throwable,
+        ) : Failure<T>(throwable)
+    }
+
+    internal companion object {
+        internal suspend fun <T : Any> ktorFailure(throwable: Throwable): Failure<T> =
+            when (throwable) {
+                is ResponseException -> {
+                    val error: Error? = try {
+                        Json.decodeFromString(throwable.response.content.readRemaining().readText())
+                    } catch (e: SerializationException) {
+                        null
+                    }
+
+                    if (throwable.response.status == HttpStatusCode.Unauthorized) {
+                        Failure.Unauthorized(
+                            throwable = throwable,
+                            httpStatusCode = throwable.response.status.value,
+                            error = error,
+                        )
+                    } else {
+                        Failure.Error(
+                            throwable = throwable,
+                            httpStatusCode = throwable.response.status.value,
+                            error = error,
+                        )
+                    }
+                }
+                else -> Failure.Generic(throwable)
+            }
+    }
 }

--- a/common/core/src/commonMain/kotlin/com/trafi/core/HttpClient.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/core/HttpClient.kt
@@ -1,6 +1,9 @@
 package com.trafi.core
 
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -9,7 +12,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.serialization.json.Json
 
-internal fun httpClient(apiKey: String) = HttpClient {
+internal val ApiConfiguration.defaultHttpClientConfig: HttpClientConfig<*>.() -> Unit get() = {
     install(JsonFeature) {
         val json = Json {
             isLenient = true
@@ -23,7 +26,15 @@ internal fun httpClient(apiKey: String) = HttpClient {
     }
 }
 
-internal fun ApiConfiguration.defaultHttpClient(): HttpClient = httpClient(apiKey)
+internal fun ApiConfiguration.defaultHttpClient(): HttpClient = HttpClient(defaultHttpClientConfig)
+
+internal fun <T : HttpClientEngineConfig> ApiConfiguration.httpClient(
+    engineFactory: HttpClientEngineFactory<T>,
+    config: HttpClientConfig<T>.() -> Unit,
+) = HttpClient(engineFactory) {
+    defaultHttpClientConfig()
+    config()
+}
 
 internal interface ConfiguredApi {
     val baseApiUrl: String

--- a/common/core/src/commonMain/kotlin/com/trafi/locations/LocationsApi.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/locations/LocationsApi.kt
@@ -1,23 +1,34 @@
 package com.trafi.locations
 
+import com.trafi.core.ApiConfiguration
 import com.trafi.core.ApiResult
-import com.trafi.core.httpClient
+import com.trafi.core.ConfiguredApi
+import com.trafi.core.api
+import com.trafi.core.defaultHttpClient
 import com.trafi.core.model.AutoCompleteLocation
 import com.trafi.core.model.AutoCompleteLocations
 import com.trafi.core.model.LatLng
 import com.trafi.core.model.Location
 import com.trafi.core.model.ReverseGeocodeResponse
+import io.ktor.client.HttpClient
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 
-class LocationsApi(
-    private val baseApiUrl: String,
-    apiKey: String,
-    private val regionId: String
-) {
-    private val httpClient = httpClient(apiKey = apiKey).config {
+class LocationsApi internal constructor(
+    config: ApiConfiguration,
+    private val regionId: String,
+    httpClient: HttpClient,
+) : ConfiguredApi by config.api() {
+
+    constructor(config: ApiConfiguration, regionId: String) : this(
+        config = config,
+        regionId = regionId,
+        httpClient = config.defaultHttpClient(),
+    )
+
+    private val httpClient = httpClient.config {
         defaultRequest {
             header("accept-language", "en") // required for v1/autocomplete
         }
@@ -25,7 +36,7 @@ class LocationsApi(
 
     suspend fun search(
         query: String,
-        coordinate: LatLng? = null
+        coordinate: LatLng? = null,
     ): ApiResult<AutoCompleteLocations> = try {
         val result = httpClient.get<AutoCompleteLocations>(baseApiUrl + "v1/autocomplete") {
             parameter("q", query)

--- a/common/core/src/commonMain/kotlin/com/trafi/locations/LocationsApi.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/locations/LocationsApi.kt
@@ -47,16 +47,16 @@ class LocationsApi internal constructor(
         }
         ApiResult.Success(result)
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 
     suspend fun resolveLocation(location: AutoCompleteLocation): ApiResult<Location> = try {
         location.toLocation()?.let { ApiResult.Success(it) }
             ?: httpClient.get<AutoCompleteLocation>(baseApiUrl + "v1/autocomplete/id/${location.id}")
                 .toLocation()?.let { ApiResult.Success(it) }
-            ?: ApiResult.Failure(IllegalArgumentException("Failed to resolve coordinate for location id ${location.id}"))
+            ?: ApiResult.Failure.Generic(IllegalArgumentException("Failed to resolve coordinate for location id ${location.id}"))
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 
     suspend fun resolveAddress(coordinate: LatLng): ApiResult<ReverseGeocodeResponse> = try {
@@ -67,7 +67,7 @@ class LocationsApi internal constructor(
             }
         ApiResult.Success(result)
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 }
 

--- a/common/core/src/commonMain/kotlin/com/trafi/maas/transit/ui/internal/NearbyTransitScheduleBadgesConstants.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/maas/transit/ui/internal/NearbyTransitScheduleBadgesConstants.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED_PARAMETER")
+
 package com.trafi.maas.transit.ui.internal
 
 import com.trafi.ui.theme.internal.CurrentTheme

--- a/common/core/src/commonMain/kotlin/com/trafi/maas/transit/ui/internal/NearbyTransitStopBadgeConstants.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/maas/transit/ui/internal/NearbyTransitStopBadgeConstants.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED_PARAMETER")
+
 package com.trafi.maas.transit.ui.internal
 
 import com.trafi.ui.theme.internal.CurrentTheme

--- a/common/core/src/commonMain/kotlin/com/trafi/routes/RoutesApi.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/routes/RoutesApi.kt
@@ -1,14 +1,22 @@
 package com.trafi.routes
 
+import com.trafi.core.ApiConfiguration
 import com.trafi.core.ApiResult
-import com.trafi.core.httpClient
+import com.trafi.core.ConfiguredApi
+import com.trafi.core.api
+import com.trafi.core.defaultHttpClient
 import com.trafi.core.model.Location
 import com.trafi.core.model.RoutesResult
+import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 
-class RoutesApi(private val baseApiUrl: String, apiKey: String) {
-    private val httpClient = httpClient(apiKey = apiKey)
+class RoutesApi internal constructor(
+    config: ApiConfiguration,
+    private val httpClient: HttpClient,
+) : ConfiguredApi by config.api() {
+
+    constructor(config: ApiConfiguration) : this(config, config.defaultHttpClient())
 
     suspend fun search(start: Location, end: Location): ApiResult<RoutesResult> = try {
         val result = httpClient.get<RoutesResult>(baseApiUrl + "v1/routes") {

--- a/common/core/src/commonMain/kotlin/com/trafi/routes/RoutesApi.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/routes/RoutesApi.kt
@@ -29,6 +29,6 @@ class RoutesApi internal constructor(
         }
         ApiResult.Success(result)
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 }

--- a/common/core/src/commonMain/kotlin/com/trafi/users/UsersApi.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/users/UsersApi.kt
@@ -24,7 +24,7 @@ class UsersApi internal constructor(
         }
         ApiResult.Success(result)
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 
     suspend fun updateProfile(profile: Profile? = null): ApiResult<User> = try {
@@ -33,6 +33,6 @@ class UsersApi internal constructor(
         }
         ApiResult.Success(result)
     } catch (e: Throwable) {
-        ApiResult.Failure(e)
+        ApiResult.ktorFailure(e)
     }
 }

--- a/common/core/src/commonTest/kotlin/com/trafi/core/ApiResultTests.kt
+++ b/common/core/src/commonTest/kotlin/com/trafi/core/ApiResultTests.kt
@@ -1,0 +1,163 @@
+package com.trafi.core
+
+import com.trafi.core.model.DrivingLicence
+import com.trafi.core.model.Error
+import com.trafi.core.model.Identity
+import com.trafi.core.model.PhoneNumber
+import com.trafi.core.model.Profile
+import com.trafi.core.model.UpdateProfileParameters
+import com.trafi.core.model.User
+import com.trafi.core.model.UserTerms
+import com.trafi.test.runBlocking
+import com.trafi.users.UsersApi
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.content.TextContent
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.auth.parseAuthorizationHeader
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ApiResultTests {
+    @Test
+    fun successfulResultReturns200(): Unit = runBlocking {
+        val usersApi = MockUsersApi(ApiConfiguration(getIdToken = { validIdToken }))
+        val result = usersApi.createOrGetUser()
+        assertTrue(result is ApiResult.Success)
+        assertEquals(mockUser, result.value)
+    }
+
+    @Test
+    fun unauthorizedResultReturns401(): Unit = runBlocking {
+        val usersApi = MockUsersApi(ApiConfiguration(getIdToken = { null }))
+        val result = usersApi.createOrGetUser()
+        assertTrue(result is ApiResult.Failure.Unauthorized)
+        assertEquals(result.httpStatusCode, 401)
+        assertNotNull(result.error)
+    }
+
+    @Test
+    fun internalServerErrorReturns500(): Unit = runBlocking {
+        val usersApi = MockUsersApi(ApiConfiguration(getIdToken = { validIdToken }))
+        val result = usersApi.createOrGetUser(profile = bomb500)
+        assertTrue(result is ApiResult.Failure.Error)
+        assertEquals(result.httpStatusCode, 500)
+    }
+}
+
+@Suppress("TestFunctionName")
+private fun MockUsersApi(configuration: ApiConfiguration): UsersApi =
+    UsersApi(configuration, configuration.mockHttpClient)
+
+@Suppress("TestFunctionName")
+private fun ApiConfiguration(getIdToken: () -> String?): ApiConfiguration = ApiConfiguration(
+    baseUrl = "https://trafi.com/",
+    apiKey = "123",
+    getIdToken = getIdToken,
+)
+
+private const val validIdToken = "valid"
+
+private val ApiConfiguration.mockHttpClient: HttpClient
+    get() = httpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                when (request.url.fullPath) {
+                    "/v1/users/me" -> {
+                        if (request.bearerToken == validIdToken) {
+                            val profile = request.parseBodyJson
+                            if (profile == bomb500) {
+                                respondErrorJson(HttpStatusCode.InternalServerError)
+                            } else {
+                                respondJson(mockUser)
+                            }
+                        } else {
+                            respondErrorJson(
+                                HttpStatusCode.Unauthorized,
+                                Error(developerMessage = "Invalid id token ${request.bearerToken}")
+                            )
+                        }
+                    }
+                    else -> error("Unhandled ${request.url}")
+                }
+            }
+        }
+    }
+
+private val HttpRequestData.bearerToken: String?
+    get() {
+        val rawHeader = headers["Authorization"] ?: return null
+        val header = parseAuthorizationHeader(rawHeader) as? HttpAuthHeader.Single ?: return null
+        if (header.authScheme != "Bearer") return null
+        return header.blob
+    }
+
+private val HttpRequestData.parseBodyJson: Profile?
+    get() {
+        val string = (body as TextContent).text
+        val params: UpdateProfileParameters = Json.decodeFromString(string)
+        return params.profile
+    }
+
+private inline fun <reified T> MockRequestHandleScope.respondJson(
+    content: T,
+    status: HttpStatusCode = HttpStatusCode.OK,
+    headers: Headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString())),
+): HttpResponseData = respond(Json.encodeToString(content), status, headers)
+
+private inline fun MockRequestHandleScope.respondErrorJson(
+    status: HttpStatusCode,
+    content: Error? = null,
+    headers: Headers = content?.let {
+        headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+    } ?: headersOf(),
+): HttpResponseData =
+    respondError(status, content?.let { Json.encodeToString(it) } ?: status.description, headers)
+
+private val mockUser: User = User(
+    id = "user_id",
+    identity = Identity(
+        verificationStatus = Identity.VerificationStatus.NOT_VERIFIED,
+    ),
+    profile = Profile(
+        gender = Profile.Gender.NOT_SPECIFIED,
+        ext = emptyMap(),
+    ),
+    phoneNumber = PhoneNumber(
+        verificationStatus = PhoneNumber.VerificationStatus.NOT_VERIFIED,
+    ),
+    providerAccounts = emptyList(),
+    drivingLicence = DrivingLicence(
+        categories = emptyList(),
+        verificationStatus = DrivingLicence.VerificationStatus.NOT_VERIFIED,
+    ),
+    terms = UserTerms(
+        platformTerms = emptyList(),
+        providerTerms = emptyList(),
+        declinedPlatformTerms = emptyList(),
+        declinedProviderTerms = emptyList(),
+    ),
+    paymentMethods = null,
+    memberships = null,
+)
+
+private val bomb500: Profile = Profile(
+    gender = Profile.Gender.NOT_SPECIFIED,
+    ext = emptyMap(),
+    firstName = "500"
+)

--- a/common/core/src/commonTest/kotlin/com/trafi/test/RunBlocking.kt
+++ b/common/core/src/commonTest/kotlin/com/trafi/test/RunBlocking.kt
@@ -1,0 +1,5 @@
+package com.trafi.test
+
+import kotlinx.coroutines.CoroutineScope
+
+expect fun <T> runBlocking(block: suspend CoroutineScope.() -> T): T

--- a/common/core/src/iosTest/kotlin/com/trafi/test/RunBlockinng.kt
+++ b/common/core/src/iosTest/kotlin/com/trafi/test/RunBlockinng.kt
@@ -1,0 +1,6 @@
+package com.trafi.test
+
+import kotlinx.coroutines.CoroutineScope
+
+actual fun <T> runBlocking(block: suspend CoroutineScope.() -> T): T =
+    kotlinx.coroutines.runBlocking(block = block)

--- a/ios/MaasCore/Sources/MaasCore/Api/ApiError.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/ApiError.swift
@@ -1,8 +1,20 @@
+/**
+ - Tag: ApiError
+ */
 enum ApiError: Swift.Error, Equatable, Hashable {
-    case httpError
-    case parseError
-    case error(String)
-    case unknownError
-    
-    case apiResultFailure
+    /**
+     The server returned 401.
+     - Parameter error: optional error message.
+     */
+    case unauthorized(error: Error?)
+    /**
+     The server returned an error.
+     - Parameter error: optional error message.
+     */
+    case error(error: Error?)
+    /**
+     A generic failure not covered by the more specific [ApiError](x-source-tag://ApiError) types.
+     - Parameter developerMessage: optional message to help identify the error.
+     */
+    case failure(developerMessage: String?)
 }

--- a/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
@@ -27,14 +27,21 @@ private extension ApiKotlinFlowPublisher {
             self.subscriber = subscriber
             
             self.closable = flow.watch { result in
-                if let success = result as? ApiResultSuccess<T> {
+                switch result {
+                case let success as ApiResultSuccess<T>:
                     let _ = subscriber.receive(success.value)
-                } else if let failure = result as? ApiResultFailure<T> {
-                    // TODO: failure.exception as ApiError ???
-                    subscriber.receive(completion: .failure(ApiError.apiResultFailure))
-                } else {
-                    let message = "ApiResult: unable to parse to ApiResultSuccess or ApiResultFailure, Expecting type: \(T.self)"
-                    subscriber.receive(completion: .failure(ApiError.error(message)))
+                case let failure as ApiResultFailureUnauthorized<T>:
+                    subscriber.receive(completion: .failure(ApiError.unauthorized(error: failure.error)))
+                case let failure as ApiResultFailureError<T>:
+                    subscriber.receive(completion: .failure(ApiError.error(error: failure.error)))
+                case let failure as ApiResultFailureGeneric<T>:
+                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: failure.throwable.message)))
+                case let failure as ApiResultFailure<T>:
+                    let message = "ApiResult: could not parse \(failure) as sub-type of ApiResultFailure. Failure message: \(failure.throwable.message ?? "nil")"
+                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: message)))
+                default:
+                    let message = "ApiResult: unable to parse \(result) as ApiResultSuccess or ApiResultFailure"
+                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: message)))
                 }
             } completion: {
                 subscriber.receive(completion: .finished)

--- a/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
@@ -31,17 +31,17 @@ private extension ApiKotlinFlowPublisher {
                 case let success as ApiResultSuccess<T>:
                     let _ = subscriber.receive(success.value)
                 case let failure as ApiResultFailureUnauthorized<T>:
-                    subscriber.receive(completion: .failure(ApiError.unauthorized(error: failure.error)))
+                    subscriber.receive(completion: .failure(.unauthorized(error: failure.error)))
                 case let failure as ApiResultFailureError<T>:
-                    subscriber.receive(completion: .failure(ApiError.error(error: failure.error)))
+                    subscriber.receive(completion: .failure(.error(error: failure.error)))
                 case let failure as ApiResultFailureGeneric<T>:
-                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: failure.throwable.message)))
+                    subscriber.receive(completion: .failure(.failure(developerMessage: failure.throwable.message)))
                 case let failure as ApiResultFailure<T>:
                     let message = "ApiResult: could not parse \(failure) as sub-type of ApiResultFailure. Failure message: \(failure.throwable.message ?? "nil")"
-                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: message)))
+                    subscriber.receive(completion: .failure(.failure(developerMessage: message)))
                 default:
                     let message = "ApiResult: unable to parse \(result) as ApiResultSuccess or ApiResultFailure"
-                    subscriber.receive(completion: .failure(ApiError.failure(developerMessage: message)))
+                    subscriber.receive(completion: .failure(.failure(developerMessage: message)))
                 }
             } completion: {
                 subscriber.receive(completion: .finished)


### PR DESCRIPTION
- return a distinct error case for 401 unauthorized errors (`ApiError.unauthorized` in iOS, `ApiResult.Failure.Unauthorized` in common and Android)
- parse and return the API's `Error` response body when an error response is received
- update `LocationsApi` and `RoutesApi` to use `ApiConfiguration`
- basic unit test setup for `common:core` Kotlin multiplatform tests