### PR TITLE
Expose 403 Forbidden errors

### DIFF
--- a/common/core/src/commonMain/kotlin/com/trafi/core/ApiResult.kt
+++ b/common/core/src/commonMain/kotlin/com/trafi/core/ApiResult.kt
@@ -21,18 +21,40 @@ sealed class ApiResult<out T : Any> {
     class Success<T : Any>(val value: T) : ApiResult<T>()
 
     sealed class Failure<T : Any>(val throwable: Throwable) : ApiResult<T>() {
+        /**
+         * The server returned 401 Unauthorized.
+         * The Authorization header Bearer token retrieved using [ApiConfiguration.getIdToken]
+         * may be invalid or expired.
+         */
         class Unauthorized<T : Any>(
             throwable: Throwable,
             val httpStatusCode: Int,
             val error: com.trafi.core.model.Error? = null,
         ) : Failure<T>(throwable)
 
+        /**
+         * The server returned 403 Forbidden.
+         * The x-api-key header retrieved using [ApiConfiguration.apiKey]
+         * may be invalid or not subscribed to the API.
+         */
+        class Forbidden<T : Any>(
+            throwable: Throwable,
+            val httpStatusCode: Int,
+            val error: com.trafi.core.model.Error? = null,
+        ) : Failure<T>(throwable)
+
+        /**
+         * The server returned an error not covered by the more specific [Failure] types.
+         */
         class Error<T : Any>(
             throwable: Throwable,
             val httpStatusCode: Int,
             val error: com.trafi.core.model.Error? = null,
         ) : Failure<T>(throwable)
 
+        /**
+         * A generic failure not covered by the more specific [Failure] types.
+         */
         class Generic<T : Any>(
             throwable: Throwable,
         ) : Failure<T>(throwable)
@@ -48,14 +70,18 @@ sealed class ApiResult<out T : Any> {
                         null
                     }
 
-                    if (throwable.response.status == HttpStatusCode.Unauthorized) {
-                        Failure.Unauthorized(
+                    when (throwable.response.status) {
+                        HttpStatusCode.Unauthorized -> Failure.Unauthorized(
                             throwable = throwable,
                             httpStatusCode = throwable.response.status.value,
                             error = error,
                         )
-                    } else {
-                        Failure.Error(
+                        HttpStatusCode.Forbidden -> Failure.Forbidden(
+                            throwable = throwable,
+                            httpStatusCode = throwable.response.status.value,
+                            error = error,
+                        )
+                        else -> Failure.Error(
                             throwable = throwable,
                             httpStatusCode = throwable.response.status.value,
                             error = error,

--- a/ios/MaasCore/Sources/MaasCore/Api/ApiConfiguration.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/ApiConfiguration.swift
@@ -17,7 +17,13 @@ class ApiConfiguration: ApiConfig {
 
 public protocol ApiConfig {
     var baseUrl: String { get }
+    /**
+     - Tag: ApiConfig.apiKey
+     */
     var apiKey: String { get }
+    /**
+     - Tag: ApiConfig.getIdToken
+     */
     func getIdToken() -> String?
     var logger: Logger? { get }
 }

--- a/ios/MaasCore/Sources/MaasCore/Api/ApiError.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/ApiError.swift
@@ -3,12 +3,19 @@
  */
 public enum ApiError: Swift.Error, Equatable, Hashable {
     /**
-     The server returned 401.
+     The server returned 401 Unauthorized.
+     The Authorization header Bearer token retrieved using [ApiConfig.getIdToken](x-source-tag://ApiConfig.getIdToken) may be invalid or expired.
      - Parameter error: optional error message.
      */
     case unauthorized(error: CoreBinary.Error?)
     /**
-     The server returned an error.
+     The server returned 403 Forbidden.
+     The x-api-key header retrieved using [ApiConfig.apiKey](x-source-tag://ApiConfig.apiKey) may be invalid or not subscribed to the API.
+     - Parameter error: optional error message.
+     */
+    case forbidden(error: CoreBinary.Error?)
+    /**
+     The server returned an error not covered by the more specific [ApiError](x-source-tag://ApiError) types..
      - Parameter error: optional error message.
      */
     case error(error: CoreBinary.Error?)

--- a/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
+++ b/ios/MaasCore/Sources/MaasCore/Api/Utils/ApiKotlinFlowPublisher.swift
@@ -56,6 +56,8 @@ extension ApiError {
         switch result {
         case let unauthorizedFailure as ApiResultFailureUnauthorized<T>:
             self = .unauthorized(error: unauthorizedFailure.error)
+        case let forbiddenFailure as ApiResultFailureForbidden<T>:
+            self = .forbidden(error: forbiddenFailure.error)
         case let errorFailure as ApiResultFailureError<T>:
             self = .error(error: errorFailure.error)
         case let genericFailure as ApiResultFailureGeneric<T>:


### PR DESCRIPTION
Expose 403 as Kotlin `ApiResult.Failure.Forbidden` and Swift `ApiError.forbidden`. This typically corresponds to an invalid API key or when the API key has not subscribed to the API.