### PR TITLE
Android Gradle plugin 7.0.0-alpha07

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ at this time, but some small contributions are welcome.
 ## Android & Kotlin multiplatform
 
 ### Set up Android Studio
-1. [Install Android Studio][install-as] version Arctic Fox (2020.3.1) Canary 6
+1. [Install Android Studio][install-as] version Arctic Fox (2020.3.1) Canary 7
 1. [Install the Kotlin Multiplatform Mobile plugin][install-kmm-plugin]
 
 ### Launch sample apps

--- a/buildSrc/src/main/resources/versions.properties
+++ b/buildSrc/src/main/resources/versions.properties
@@ -1,6 +1,6 @@
 # Versions
 # These are defined here as they are needed to configure the buildSrc project itself
 version.kotlin=1.4.21-2
-version.androidGradlePlugin=7.0.0-alpha06
+version.androidGradlePlugin=7.0.0-alpha07
 # https://github.com/Karumi/Shot
 version.shot=5.7.0


### PR DESCRIPTION
Fixes some tooling issues present in 7.0.0-alpha06.

Requires Android Studio Arctic Fox (2020.3.1) Canary 7.